### PR TITLE
Optimize cuckoo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/dgryski/go-highway v0.0.0-20210309212254-61406496927c
 	github.com/gtank/ristretto255 v0.1.2
 	github.com/intel-go/cpuid v0.0.0-20210602155658-5747e5cec0d9 // indirect
+	github.com/minio/highwayhash v1.0.2
 	github.com/spaolacci/murmur3 v1.1.0
 	github.com/zeebo/blake3 v0.2.0
 	golang.org/x/crypto v0.0.0-20191106202628-ed6320f186d4

--- a/go.sum
+++ b/go.sum
@@ -180,6 +180,8 @@ github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNx
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
+github.com/minio/highwayhash v1.0.2 h1:Aak5U0nElisjDCfPSG79Tgzkn2gl66NxOMspRrKnA/g=
+github.com/minio/highwayhash v1.0.2/go.mod h1:BQskDq+xkJ12lmlUUi7U0M5Swg3EWR+dLTk+kldvVxY=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
@@ -314,6 +316,7 @@ golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20181026203630-95b1ffbd15a5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190129075346-302c3dd5f1cc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190130150945-aca44879d564/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190403152447-81d4e9dc473e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/internal/crypto/crypto.go
+++ b/internal/crypto/crypto.go
@@ -72,7 +72,7 @@ func XorCipherWithPRG(s *blake3.Hasher, seed []byte, src []byte) (dst []byte, er
 }
 
 // H(seed, src), where H is modeled as a pseudorandom generator.
-func PseudorandomGeneratorWithBlake3(s *blake3.Hasher, seed []byte, length int) (dst []byte, err error) {
+func PseudorandomGeneratorWithBlake3(s *blake3.Hasher, seed []byte, length int) (dst []byte) {
 	// purposely allocate more random bytes to fill in the remaining bits
 	// that does not fit in a byte
 	tmp := make([]byte, (length+7)/8)
@@ -83,7 +83,7 @@ func PseudorandomGeneratorWithBlake3(s *blake3.Hasher, seed []byte, length int) 
 	d.Read(tmp)
 	// extract pseudorandom bytes to bits
 	util.ExtractBytesToBits(tmp, dst)
-	return dst[:length], nil
+	return dst[:length]
 }
 
 // aes gcm(seed, src)

--- a/internal/crypto/crypto_test.go
+++ b/internal/crypto/crypto_test.go
@@ -172,7 +172,7 @@ func TestPseudorandomGeneratorWithBlake3(t *testing.T) {
 	seed := make([]byte, 424)
 	r.Read(seed)
 	n := 212
-	p, _ := PseudorandomGeneratorWithBlake3(blake3.New(), seed, n)
+	p := PseudorandomGeneratorWithBlake3(blake3.New(), seed, n)
 	if bytes.Equal(make([]byte, n), p) {
 		t.Fatalf("pseudorandom should not be 0")
 	}

--- a/internal/cuckoo/cuckoo.go
+++ b/internal/cuckoo/cuckoo.go
@@ -3,6 +3,7 @@ package cuckoo
 import (
 	"bytes"
 	"fmt"
+	"math"
 	"math/rand"
 	"time"
 
@@ -16,23 +17,8 @@ const (
 	// Each reinsertion kicked off 1 egg (item) and replace it
 	// with the item being reinserted, and then reinsert the kicked off egg
 	ReinsertLimit = 200
-	// index returned to signify the item is pushed on to the stash
-	// instead of the bucket
-	StashHidx = 4
-	// Bucket size parameter
-	Factor = 2
+	Factor        = 1.4
 )
-
-var stashSize = map[uint8]uint8{
-	// key is log_2(|X|)
-	// value is # of elements in stash
-	// values taken from Phasing: PSI using permutation-based hashing
-	8:  12,
-	12: 6,
-	16: 4,
-	20: 3,
-	24: 2,
-}
 
 // a value holds the inserted item, and the index of
 // the hash function used to compute which bucket index
@@ -43,34 +29,50 @@ type value struct {
 	bucketIdx uint64
 }
 
+func (v *value) empty() bool {
+	return v == nil
+}
+
 // A Cuckoo represents a 3-way Cuckoo hash table data structure
 // that contains buckets and a stash with 3 hash functions
 type Cuckoo struct {
 	//hashmap (k, v) -> k: bucket index, v: value
-	buckets map[uint64]value
+	buckets []*value
 	// Total bucket count, len(bucket)
 	bucketSize uint64
 	// 3 hash functions h_0, h_1, h_2
 	hashers [Nhash]hash.Hasher
-	// array of values
-	stash []value
+}
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
 }
 
 // NewCuckoo instantiate the struct Cuckoo with a bucket of size 2 * size,
 // a stash and 3 seeded hash functions for the 3-way cuckoo hashing.
 func NewCuckoo(size uint64, seeds [Nhash][]byte) *Cuckoo {
 	bSize := max(1, uint64(Factor*float64(size)))
+	//bSize := max(1, uint64(FindBucketSize(size)*float64(size)))
 	var hashers [Nhash]hash.Hasher
 	for i, s := range seeds {
-		hashers[i], _ = hash.New(hash.Highway, s)
+		hashers[i], _ = hash.New(hash.HighwayMinio, s)
 	}
 
 	return &Cuckoo{
-		buckets:    make(map[uint64]value, bSize),
+		buckets:    make([]*value, bSize),
 		bucketSize: bSize,
 		hashers:    hashers,
-		stash:      make([]value, findStashSize(size)),
 	}
+}
+
+func FindBucketSize(size uint64) float64 {
+	if size == 0 {
+		return 0
+	}
+	a := 210
+	b := math.Log2(float64(size)) - 256
+
+	return (40 - b) / float64(a)
 }
 
 // hash returns the result of h0(item), h1(item), h2(item)
@@ -91,14 +93,12 @@ func doHash(item []byte, hasher hash.Hasher) uint64 {
 
 // bucketIndex computes the bucket index
 func (c *Cuckoo) bucketIndex(hash uint64) uint64 {
-	return uint64(hash % c.bucketSize)
+	return hash % c.bucketSize
 }
 
 // bucketIndices returns the 3 possible bucket indices of an item
-func (c *Cuckoo) BucketIndices(item []byte) [Nhash]uint64 {
-	var idx [Nhash]uint64
-	hashes := c.hash(item)
-	for i, h := range hashes {
+func (c *Cuckoo) BucketIndices(item []byte) (idx [Nhash]uint64) {
+	for i, h := range c.hash(item) {
 		idx[i] = c.bucketIndex(h)
 	}
 
@@ -115,7 +115,7 @@ func (c *Cuckoo) Insert(item []byte) error {
 	bucketIndices := c.BucketIndices(item)
 
 	// check if item has already been inserted:
-	if found := c.Exists(item); found {
+	if found := c.Exists(item, bucketIndices); found {
 		return nil
 	}
 
@@ -141,9 +141,9 @@ func (c *Cuckoo) tryAdd(item []byte, bucketIndices [Nhash]uint64, ignore bool, e
 			continue
 		}
 
-		if _, occupied := c.buckets[bIdx]; !occupied {
+		if c.buckets[bIdx].empty() {
 			// this is a free slot
-			c.buckets[bIdx] = value{item, uint8(hIdx), bIdx}
+			c.buckets[bIdx] = &value{item, uint8(hIdx), bIdx}
 			return true
 		}
 	}
@@ -151,20 +151,16 @@ func (c *Cuckoo) tryAdd(item []byte, bucketIndices [Nhash]uint64, ignore bool, e
 }
 
 // tryGreedyAdd evicts a random occupied slots, inserts the item to the evicted slot
-// and reinserts the evicted item.
-// after ReinsertLimit number of reinsertions, it pushes the evicted item onto the stash
+// and reinserts the evicted item
 // return false and the last evicted item, if reinsertions failed
 func (c *Cuckoo) tryGreedyAdd(item []byte, bucketIndices [Nhash]uint64) (homeLessItem []byte, added bool) {
-	// seed rand to choose a random occupied slot
-	rand.Seed(time.Now().UnixNano())
-
 	for i := 1; i < ReinsertLimit; i++ {
 		// select a random slot to be evicted
-		evictedHIdx := rand.Intn(Nhash - 1)
+		evictedHIdx := rand.Int31n(Nhash)
 		evictedBIdx := bucketIndices[evictedHIdx]
 		evictedItem := c.buckets[evictedBIdx]
 		// insert the item in the evicted slot
-		c.buckets[evictedBIdx] = value{item, uint8(evictedHIdx), evictedBIdx}
+		c.buckets[evictedBIdx] = &value{item, uint8(evictedHIdx), evictedBIdx}
 
 		evictedBucketIndices := c.BucketIndices(evictedItem.item)
 		// try to reinsert the evicted items
@@ -178,71 +174,44 @@ func (c *Cuckoo) tryGreedyAdd(item []byte, bucketIndices [Nhash]uint64) (homeLes
 		bucketIndices = evictedBucketIndices
 	}
 
-	// last resort, push the evicted item onto the stash
-	for i, s := range c.stash {
-		// empty slot
-		if len(s.item) == 0 {
-			c.stash[i] = value{item, uint8(StashHidx), c.bucketSize + uint64(i)}
-			return nil, true
-		}
-	}
-
-	// even a stash is not enough to insert the item
 	return item, false
 }
 
 // GetHashIdx finds the index of the hash function {0, 1, 2}
 // that gives the bucket index, and a boolean found
-// if item is on stash, return StashHidx
 // if item is not inserted, return the max value 255, and found is set to false.
 func (c *Cuckoo) GetHashIdx(item []byte) (hIdx uint8, found bool) {
-	if c.onStash(item) {
-		return uint8(StashHidx), true
-	}
-
-	return c.onBucketAtIndex(item)
+	return c.onBucketAtIndex(item, c.BucketIndices(item))
 }
 
 // OnBucket returns true if item is inserted in cuckoo hash table.
-func (c *Cuckoo) onBucket(item []byte) (found bool) {
-	_, found = c.onBucketAtIndex(item)
+func (c *Cuckoo) onBucket(item []byte, bucketIndices [Nhash]uint64) (found bool) {
+	_, found = c.onBucketAtIndex(item, bucketIndices)
 	return found
 }
 
-func (c *Cuckoo) onBucketAtIndex(item []byte) (uint8, bool) {
-	bucketIndices := c.BucketIndices(item)
+func (c *Cuckoo) onBucketAtIndex(item []byte, bucketIndices [Nhash]uint64) (uint8, bool) {
 	for _, bIdx := range bucketIndices {
-		if v, found := c.buckets[bIdx]; found && bytes.Equal(v.item, item) {
+		if c.buckets[bIdx] != nil && len(c.buckets[bIdx].item) > 0 && bytes.Equal(c.buckets[bIdx].item, item) {
 			// the index for hash function is the same as the
 			// index for the bucketIndices
-			return v.hIdx, true
+			return c.buckets[bIdx].hIdx, true
 		}
 	}
 
-	// Not found in bucket
 	return uint8(255), false
 }
 
-func (c *Cuckoo) onStash(item []byte) (found bool) {
-	for _, v := range c.stash {
-		if len(v.item) > 0 && bytes.Equal(v.item, item) {
-			return true
-		}
-	}
-
-	return false
-}
-
 // Exists returns true if an item is inserted in cuckoo, false otherwise
-func (c *Cuckoo) Exists(item []byte) (found bool) {
-	return c.onBucket(item) || c.onStash(item)
+func (c *Cuckoo) Exists(item []byte, bucketIndices [Nhash]uint64) (found bool) {
+	return c.onBucket(item, bucketIndices)
 }
 
 // LoadFactor returns the ratio of occupied buckets with the overall bucketSize
 func (c *Cuckoo) LoadFactor() (factor float64) {
 	occupation := 0
 	for _, v := range c.buckets {
-		if len(v.item) > 0 {
+		if !v.empty() {
 			occupation += 1
 		}
 	}
@@ -253,20 +222,16 @@ func (c *Cuckoo) LoadFactor() (factor float64) {
 // Len returns the total size of the cuckoo struct
 // which is equal to bucketSize + stashSize
 func (c *Cuckoo) Len() uint64 {
-	return c.bucketSize + uint64(c.StashSize())
+	return c.bucketSize //+ uint64(c.StashSize())
 }
 
-func (v value) oprfInput() []byte {
+func (v *value) oprfInput() []byte {
 	// no item inserted, return dummy value
-	if v.item == nil {
+	if v.empty() {
 		return []byte{255}
 	}
 
-	if v.hIdx != StashHidx {
-		return append(v.item, v.hIdx)
-	}
-
-	return v.item
+	return append(v.item, v.hIdx)
 }
 
 // OPRFInput returns the OPRF input for KKRT Receiver
@@ -280,59 +245,33 @@ func (c *Cuckoo) OPRFInput() [][]byte {
 		i++
 	}
 
-	i := c.bucketSize
-	for _, v := range c.stash {
-		r[i] = v.oprfInput()
-		i++
-	}
-
 	return r
 }
 
-func (v value) GetItem() []byte {
+func (v *value) GetItem() []byte {
 	return v.item
 }
 
-func (v value) GetHashIdx() uint8 {
+func (v *value) GetHashIdx() uint8 {
 	return v.hIdx
 }
 
-func (v value) GetBucketIdx() uint64 {
+func (v *value) GetBucketIdx() uint64 {
 	return v.bucketIdx
 }
 
-func (c *Cuckoo) Bucket() map[uint64]value {
-	return c.buckets
+func (c *Cuckoo) Bucket() []*value {
+	if c.buckets != nil {
+		clone := make([]*value, len(c.buckets))
+		copy(clone, c.buckets)
+		return clone
+	} else {
+		return nil
+	}
 }
 
 func (c *Cuckoo) BucketSize() int {
 	return int(c.bucketSize)
-}
-
-func (c *Cuckoo) Stash() []value {
-	return c.stash
-}
-
-func (c *Cuckoo) StashSize() int {
-	return len(c.stash)
-}
-
-// findStashSize is a helper function that selects the correct stash size
-func findStashSize(size uint64) uint8 {
-	switch {
-	case size > 0 && size <= 256:
-		return stashSize[8]
-	case size > 256 && size <= 4096:
-		return stashSize[12]
-	case size > 4096 && size <= 65536:
-		return stashSize[16]
-	case size > 65536 && size <= 1048576:
-		return stashSize[20]
-	case size > 1048576:
-		return stashSize[24]
-	default:
-		return uint8(0)
-	}
 }
 
 func max(a, b uint64) uint64 {

--- a/internal/cuckoo/cuckoo.go
+++ b/internal/cuckoo/cuckoo.go
@@ -24,9 +24,8 @@ const (
 // the hash function used to compute which bucket index
 // the item is inserted in.
 type value struct {
-	item      []byte
-	hIdx      uint8
-	bucketIdx uint64
+	item []byte
+	hIdx uint8
 }
 
 func (v *value) empty() bool {
@@ -143,7 +142,7 @@ func (c *Cuckoo) tryAdd(item []byte, bucketIndices [Nhash]uint64, ignore bool, e
 
 		if c.buckets[bIdx].empty() {
 			// this is a free slot
-			c.buckets[bIdx] = &value{item, uint8(hIdx), bIdx}
+			c.buckets[bIdx] = &value{item, uint8(hIdx)}
 			return true
 		}
 	}
@@ -160,7 +159,7 @@ func (c *Cuckoo) tryGreedyAdd(item []byte, bucketIndices [Nhash]uint64) (homeLes
 		evictedBIdx := bucketIndices[evictedHIdx]
 		evictedItem := c.buckets[evictedBIdx]
 		// insert the item in the evicted slot
-		c.buckets[evictedBIdx] = &value{item, uint8(evictedHIdx), evictedBIdx}
+		c.buckets[evictedBIdx] = &value{item, uint8(evictedHIdx)}
 
 		evictedBucketIndices := c.BucketIndices(evictedItem.item)
 		// try to reinsert the evicted items
@@ -240,9 +239,8 @@ func (v *value) oprfInput() []byte {
 // if the bucket has nothing it in, it returns a dummy value: 255
 func (c *Cuckoo) OPRFInput() [][]byte {
 	r := make([][]byte, c.Len())
-	for i := range r {
-		r[i] = c.buckets[uint64(i)].oprfInput()
-		i++
+	for i, b := range c.buckets {
+		r[i] = b.oprfInput()
 	}
 
 	return r
@@ -254,10 +252,6 @@ func (v *value) GetItem() []byte {
 
 func (v *value) GetHashIdx() uint8 {
 	return v.hIdx
-}
-
-func (v *value) GetBucketIdx() uint64 {
-	return v.bucketIdx
 }
 
 func (c *Cuckoo) Bucket() []*value {

--- a/internal/cuckoo/cuckoo_test.go
+++ b/internal/cuckoo/cuckoo_test.go
@@ -59,7 +59,7 @@ func TestInsertAndGetHashIdx(t *testing.T) {
 		counter := 0
 		starttime := time.Now()
 	*/
-	for i, item := range testData {
+	for _, item := range testData {
 		if err := cuckoo.Insert(item); err != nil {
 			errCount += 1
 		}

--- a/internal/cuckoo/cuckoo_test.go
+++ b/internal/cuckoo/cuckoo_test.go
@@ -10,8 +10,8 @@ import (
 
 var (
 	bench_cuckoo *Cuckoo
-	test_n       = uint64(1e7) // 1Million
-	bench_n      = uint64(1e6) // 10 Million
+	test_n       = uint64(1e6) // 1 Million
+	bench_n      = uint64(1e6) // 1 Million
 	seeds        = makeSeeds()
 	testData     = genBytes(int(test_n))
 	benchData    = genBytes(int(bench_n))
@@ -37,9 +37,6 @@ func TestNewCuckoo(t *testing.T) {
 		{uint64(math.Pow(2, 4)), uint64(Factor * math.Pow(2, 4))},
 		{uint64(math.Pow(2, 8)), uint64(Factor * math.Pow(2, 8))},
 		{uint64(math.Pow(2, 16)), uint64(Factor * math.Pow(2, 16))},
-		//{uint64(math.Pow(2, 4)), uint64(FindBucketSize(uint64(math.Pow(2, 4))) * math.Pow(2, 4))},
-		//{uint64(math.Pow(2, 8)), uint64(FindBucketSize(uint64(math.Pow(2, 8))) * math.Pow(2, 8))},
-		//{uint64(math.Pow(2, 16)), uint64(FindBucketSize(uint64(math.Pow(2, 16))) * math.Pow(2, 16))},
 	}
 
 	for _, tt := range cuckooTests {
@@ -54,21 +51,10 @@ func TestInsertAndGetHashIdx(t *testing.T) {
 	cuckoo := NewCuckoo(test_n, seeds)
 	errCount := 0
 
-	//test Insert
-	/*
-		counter := 0
-		starttime := time.Now()
-	*/
 	for _, item := range testData {
 		if err := cuckoo.Insert(item); err != nil {
 			errCount += 1
 		}
-		/*
-			if i%1000000 == 0 {
-				counter++
-				t.Logf("inserted %dmillion in %v", counter, time.Since(starttime))
-			}
-		*/
 	}
 
 	t.Logf("To be inserted: %d, bucketSize: %d, load factor: %f, failure insertion:  %d",

--- a/internal/hash/hash.go
+++ b/internal/hash/hash.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cespare/xxhash"
 	"github.com/dchest/siphash"
 	"github.com/dgryski/go-highway"
+	"github.com/minio/highwayhash"
 	"github.com/spaolacci/murmur3"
 )
 
@@ -18,6 +19,7 @@ const (
 	Murmur3
 	XX
 	Highway
+	HighwayMinio
 )
 
 var (
@@ -58,6 +60,8 @@ func New(t int, salt []byte) (Hasher, error) {
 		return NewXXHasher(salt)
 	case Highway:
 		return NewHighwayHasher(salt)
+	case HighwayMinio:
+		return NewHighwayHasherMinio(salt)
 	default:
 		return nil, ErrUnknownHash
 	}
@@ -156,4 +160,20 @@ func NewHighwayHasher(salt []byte) (hw, error) {
 func (h hw) Hash64(p []byte) uint64 {
 	// prepend the salt in m and then Sum
 	return highway.Hash(h.key, p)
+}
+
+type hwMinio struct {
+	salt []byte
+}
+
+func NewHighwayHasherMinio(salt []byte) (hwMinio, error) {
+	if len(salt) != SaltLength {
+		return hwMinio{}, ErrSaltLengthMismatch
+	}
+
+	return hwMinio{salt: salt}, nil
+}
+
+func (h hwMinio) Hash64(p []byte) uint64 {
+	return highwayhash.Sum64(p, h.salt)
 }

--- a/internal/oprf/oprf_test.go
+++ b/internal/oprf/oprf_test.go
@@ -14,7 +14,7 @@ import (
 var (
 	network   = "tcp"
 	address   = "127.0.0.1:"
-	baseCount = 14000000
+	baseCount = 10000
 	prng      = rand.New(rand.NewSource(time.Now().UnixNano()))
 	choices   = genChoiceString()
 )

--- a/internal/oprf/oprf_test.go
+++ b/internal/oprf/oprf_test.go
@@ -14,7 +14,7 @@ import (
 var (
 	network   = "tcp"
 	address   = "127.0.0.1:"
-	baseCount = 1000
+	baseCount = 14000000
 	prng      = rand.New(rand.NewSource(time.Now().UnixNano()))
 	choices   = genChoiceString()
 )

--- a/internal/ot/alsz.go
+++ b/internal/ot/alsz.go
@@ -70,10 +70,7 @@ func (ext alsz) Send(messages [][][]byte, rw io.ReadWriter) (err error) {
 			return err
 		}
 
-		q[col], err = crypto.PseudorandomGeneratorWithBlake3(ext.g, seeds[col], ext.m)
-		if err != nil {
-			return err
-		}
+		q[col] = crypto.PseudorandomGeneratorWithBlake3(ext.g, seeds[col], ext.m)
 
 		q[col], _ = util.XorBytes(util.AndByte(s[col], u), q[col])
 	}
@@ -135,15 +132,10 @@ func (ext alsz) Receive(choices []uint8, messages [][]byte, rw io.ReadWriter) (e
 	// u^i = G(seeds[1])
 	// t^i = d^i ^ u^i
 	for col := range t {
-		t[col], err = crypto.PseudorandomGeneratorWithBlake3(ext.g, baseMsgs[col][0], ext.m)
-		if err != nil {
-			return err
-		}
+		t[col] = crypto.PseudorandomGeneratorWithBlake3(ext.g, baseMsgs[col][0], ext.m)
 
-		u, err = crypto.PseudorandomGeneratorWithBlake3(ext.g, baseMsgs[col][1], ext.m)
-		if err != nil {
-			return err
-		}
+		u = crypto.PseudorandomGeneratorWithBlake3(ext.g, baseMsgs[col][1], ext.m)
+
 		u, err = util.XorBytes(u, t[col])
 		if err != nil {
 			return err

--- a/internal/ot/improved_iknp_nco.go
+++ b/internal/ot/improved_iknp_nco.go
@@ -80,10 +80,8 @@ func (ext imprvIKNPNCO) Send(messages [][][]byte, rw io.ReadWriter) (err error) 
 			return err
 		}
 
-		q[col], err = crypto.PseudorandomGeneratorWithBlake3(ext.g, seeds[col], ext.m)
-		if err != nil {
-			return err
-		}
+		q[col] = crypto.PseudorandomGeneratorWithBlake3(ext.g, seeds[col], ext.m)
+
 		if s[col] == 0 {
 			q[col], err = util.XorBytes(u, q[col])
 			if err != nil {
@@ -172,16 +170,12 @@ func (ext imprvIKNPNCO) Receive(choices []uint8, messages [][]byte, rw io.ReadWr
 	// u^i = G(seeds[1])
 	// t^i = d^i ^ u^i
 	for col := range d {
-		u, err = crypto.PseudorandomGeneratorWithBlake3(ext.g, baseMsgs[col][1], ext.m)
-		if err != nil {
-			return err
-		}
+		u = crypto.PseudorandomGeneratorWithBlake3(ext.g, baseMsgs[col][1], ext.m)
+
 		t[col], _ = util.XorBytes(d[col], u)
 
-		u, err = crypto.PseudorandomGeneratorWithBlake3(ext.g, baseMsgs[col][0], ext.m)
-		if err != nil {
-			return err
-		}
+		u = crypto.PseudorandomGeneratorWithBlake3(ext.g, baseMsgs[col][0], ext.m)
+
 		u, _ = util.XorBytes(u, t[col])
 
 		// send w

--- a/internal/ot/improved_kkrt.go
+++ b/internal/ot/improved_kkrt.go
@@ -74,10 +74,7 @@ func (ext imprvKKRT) Send(messages [][][]byte, rw io.ReadWriter) (err error) {
 			return err
 		}
 
-		q[col], err = crypto.PseudorandomGeneratorWithBlake3(ext.g, seeds[col], ext.m)
-		if err != nil {
-			return err
-		}
+		q[col] = crypto.PseudorandomGeneratorWithBlake3(ext.g, seeds[col], ext.m)
 
 		q[col], _ = util.XorBytes(util.AndByte(s[col], u), q[col])
 	}
@@ -148,15 +145,9 @@ func (ext imprvKKRT) Receive(choices []uint8, messages [][]byte, rw io.ReadWrite
 	// u^i = G(seeds[1])
 	// t^i = d^i ^ u^i
 	for col := range d {
-		t[col], err = crypto.PseudorandomGeneratorWithBlake3(ext.g, baseMsgs[col][0], ext.m)
-		if err != nil {
-			return err
-		}
+		t[col] = crypto.PseudorandomGeneratorWithBlake3(ext.g, baseMsgs[col][0], ext.m)
 
-		u, err = crypto.PseudorandomGeneratorWithBlake3(ext.g, baseMsgs[col][1], ext.m)
-		if err != nil {
-			return err
-		}
+		u = crypto.PseudorandomGeneratorWithBlake3(ext.g, baseMsgs[col][1], ext.m)
 		u, _ = util.XorBytes(t[col], u)
 		u, _ = util.XorBytes(u, d[col])
 

--- a/pkg/kkrtpsi/kkrtpsi.go
+++ b/pkg/kkrtpsi/kkrtpsi.go
@@ -20,9 +20,7 @@ func findK(n int64) int {
 	case n > 4096 && n <= 65536:
 		return 440
 	// 2^20
-	case n > 65536 && n <= 1048576:
-		return 448
-	case n > 1048576:
+	case n > 65536:
 		return 448
 	default:
 		return 128

--- a/pkg/kkrtpsi/receiver.go
+++ b/pkg/kkrtpsi/receiver.go
@@ -154,7 +154,7 @@ func (r *Receiver) Intersect(ctx context.Context, n int64, identifiers <-chan []
 			}(i)
 		}
 
-		hasher, err := hash.New(hash.HighwayMinio, seeds[0])
+		hasher, err := hash.New(hash.Highway, seeds[0])
 		if err != nil {
 			return err
 		}

--- a/pkg/kkrtpsi/sender.go
+++ b/pkg/kkrtpsi/sender.go
@@ -120,7 +120,7 @@ func (s *Sender) Send(ctx context.Context, n int64, identifiers <-chan []byte) (
 
 		var hashtable = make([]chan uint64, cuckoo.Nhash)
 
-		hasher, err := hash.New(hash.HighwayMinio, seeds[0])
+		hasher, err := hash.New(hash.Highway, seeds[0])
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
* use slice instead of map
* Delete stash
* Can insert 10 million in 12 seconds, 100 million in less than 10 minutes.
This is massive improvement from before where inserting 20 million took 10 minutes.

Current time record for matching 2 files with 5Million identifiers and 1Million identifiers in common:
<img width="563" alt="Screen Shot 2021-08-30 at 4 53 56 PM" src="https://user-images.githubusercontent.com/17508161/131404355-e93c8bc6-bae6-43a4-8524-741a1a6ffde0.png">

clearly, stage 3 needs more work as well.