### PR TITLE
Fix spelling and basic linter errors

### DIFF
--- a/examples/receiver/main.go
+++ b/examples/receiver/main.go
@@ -52,14 +52,14 @@ func main() {
 	}
 
 	// validate protocol
-	var psi_type psi.Protocol
+	var psiType psi.Protocol
 	switch *protocol {
 	case "bpsi":
-		psi_type = psi.BPSI
+		psiType = psi.BPSI
 	case "npsi":
-		psi_type = psi.NPSI
+		psiType = psi.NPSI
 	case "dhpsi":
-		psi_type = psi.DHPSI
+		psiType = psi.DHPSI
 	default:
 		log.Printf("unsupported protocol %s", *protocol)
 		showUsageAndExit(0)
@@ -106,7 +106,7 @@ func main() {
 				v.SetNoDelay(false)
 			}
 			// make the receiver
-			receiver, _ := psi.NewReceiver(psi_type, c)
+			receiver, _ := psi.NewReceiver(psiType, c)
 			// and hand it off
 			wg.Add(1)
 			go func() {

--- a/examples/sender/main.go
+++ b/examples/sender/main.go
@@ -43,14 +43,14 @@ func main() {
 	}
 
 	// validate protocol
-	var psi_type psi.Protocol
+	var psiType psi.Protocol
 	switch *protocol {
 	case "bpsi":
-		psi_type = psi.BPSI
+		psiType = psi.BPSI
 	case "npsi":
-		psi_type = psi.NPSI
+		psiType = psi.NPSI
 	case "dhpsi":
-		psi_type = psi.DHPSI
+		psiType = psi.DHPSI
 	default:
 		log.Printf("unsupported protocol %s", *protocol)
 		showUsageAndExit(0)
@@ -85,7 +85,7 @@ func main() {
 	case *net.TCPConn:
 		v.SetNoDelay(false)
 	}
-	s, _ := psi.NewSender(psi_type, c)
+	s, _ := psi.NewSender(psiType, c)
 	ids := util.Exhaust(n, f)
 	err = s.Send(context.Background(), n, ids)
 	if err != nil {

--- a/internal/hash/hash.go
+++ b/internal/hash/hash.go
@@ -47,7 +47,7 @@ type Hasher interface {
 	Hash64([]byte) uint64
 }
 
-// NewHasher creates a hasher of type t
+// New creates a hasher of type t
 func New(t int, salt []byte) (Hasher, error) {
 	switch t {
 	case SIP:
@@ -68,7 +68,7 @@ type siphash64 struct {
 	key0, key1 uint64
 }
 
-// NewSipHash returns a SIP hasher
+// NewSIPHasher returns a SIP hasher
 // that uses the salt as a key
 func NewSIPHasher(salt []byte) (siphash64, error) {
 	if len(salt) != SaltLength {
@@ -93,7 +93,7 @@ type murmur64 struct {
 	salt []byte
 }
 
-// NewMurmur3 returns a Murmur3 hasher
+// NewMurmur3Hasher returns a Murmur3 hasher
 // that uses salt as a prefix to the
 // bytes being summed
 func NewMurmur3Hasher(salt []byte) (murmur64, error) {

--- a/internal/permutations/kensler.go
+++ b/internal/permutations/kensler.go
@@ -1,5 +1,5 @@
-// Andrew Kensler, a researcher at Pixar, introduced an interesting technique for generating the permutation of an array
-// in his 2013 paper, Correlated Multi-Jittered Sampling.
+// Package permutations implements an interesting technique for generating the permutation of an array.
+// This method was developed by Andrew Kensler, a researcher at Pixar, in his 2013 paper, Correlated Multi-Jittered Sampling.
 //
 // reference:             https://graphics.pixar.com/library/MultiJitteredSampling/paper.pdf
 // further comments from: https://afnan.io/posts/2019-04-05-explaining-the-hashed-permutation/

--- a/internal/permutations/naive.go
+++ b/internal/permutations/naive.go
@@ -15,11 +15,11 @@ func NewNaive(n int64) (naive, error) {
 	var max = big.NewInt(n - 1)
 	// Chooses a uniform random int64
 	choose := func() (int64, error) {
-		if i, err := rand.Int(rand.Reader, max); err == nil {
-			return i.Int64(), nil
-		} else {
+		i, err := rand.Int(rand.Reader, max)
+		if err != nil {
 			return 0, err
 		}
+		return i.Int64(), nil
 	}
 	// Initialize a trivial permutation
 	for i := int64(0); i < n; i++ {

--- a/internal/util/framing.go
+++ b/internal/util/framing.go
@@ -45,6 +45,9 @@ func Exhaust(n int64, r io.Reader) <-chan []byte {
 	return identifiers
 }
 
+// Exhaust2 scans for identifiers in r,
+// It expects that each indentifier is line separated with \n
+// at the end of each line.
 func Exhaust2(n int64, r io.Reader) <-chan []byte {
 	// make the output channel
 	var identifiers = make(chan []byte)

--- a/pkg/bpsi/bpsi.go
+++ b/pkg/bpsi/bpsi.go
@@ -72,16 +72,16 @@ func (bf devopsfaith) Check(identifier []byte) bool {
 
 // WriteTo marshals the entire bloomfilter to rw
 func (bf devopsfaith) WriteTo(rw io.Writer) (int64, error) {
-	if b, err := bf.bf.MarshalBinary(); err == nil {
-		l := int64(len(b))
-		if err := binary.Write(rw, binary.BigEndian, l); err != nil {
-			return 0, err
-		}
-		n, err := rw.Write(b)
-		return int64(n), err
-	} else {
+	b, err := bf.bf.MarshalBinary()
+	if err != nil {
 		return 0, err
 	}
+	l := int64(len(b))
+	if err := binary.Write(rw, binary.BigEndian, l); err != nil {
+		return 0, err
+	}
+	n, err := rw.Write(b)
+	return int64(n), err
 }
 
 // Add an identifier to a bitsAndBloom bloomfilter

--- a/pkg/bpsi/receiver.go
+++ b/pkg/bpsi/receiver.go
@@ -36,12 +36,12 @@ func (r *Receiver) Intersect(ctx context.Context, n int64, identifiers <-chan []
 
 	// stage 1: read the bloomfilter from the remote side
 	stage1 := func() error {
-		if _bf, _, err := ReadFrom(r.rw); err == nil {
-			bf = _bf
-			return nil
-		} else {
+		_bf, _, err := ReadFrom(r.rw)
+		if err != nil {
 			return err
 		}
+		bf = _bf
+		return nil
 	}
 
 	// stage 2: read local IDs and compare with the remote bloomfilter

--- a/pkg/dhpsi/dhpsi.go
+++ b/pkg/dhpsi/dhpsi.go
@@ -13,7 +13,7 @@ import (
 const (
 	// EncodedLen is the length of an encoded ristretto point
 	EncodedLen = 32
-	// PrefixedLen is the length of a prefixed email identifier
+	// EmailPrefixedLen is the length of a prefixed email identifier
 	EmailPrefixedLen = 66
 )
 
@@ -25,7 +25,7 @@ var (
 // Writers
 //
 
-// DeriveMultiplyParallelShuffler contains the necessary
+// DeriveMultiplyShuffler contains the necessary
 // machineries to derive identifiers into ristretto point
 // multiply them with secret key and permute them.
 type DeriveMultiplyShuffler struct {
@@ -155,30 +155,29 @@ type Reader struct {
 // of the DeriveMultiplyShuffler or the Writer and reads encoded ristretto hashes and
 // multiplies them using gr.
 func NewMultiplyReader(r io.Reader, gr Ristretto) (*MultiplyReader, error) {
-	if r, err := NewReader(r); err != nil {
+	rr, err := NewReader(r)
+	if err != nil {
 		return nil, err
-	} else {
-		return &MultiplyReader{r: r, gr: gr}, nil
 	}
+	return &MultiplyReader{r: rr, gr: gr}, nil
 }
 
-// Read reads a point from the underyling reader, multiply it with ristretto
+// Read reads a point from the underlying reader, multiply it with ristretto
 // and write it into point. Returns io.EOF when
 // the sequence has been completely read.
 func (r *MultiplyReader) Read(point *[EncodedLen]byte) (err error) {
 	var b [EncodedLen]byte
 	if err := r.r.Read(&b); err != nil {
 		return err
-	} else {
-		r.gr.Multiply(point, b)
-		return nil
 	}
+	r.gr.Multiply(point, b)
+	return nil
 }
 
 // Max returns the expected number of matchable
 // this decoder will receive
-func (dec *MultiplyReader) Max() int64 {
-	return dec.r.max
+func (r *MultiplyReader) Max() int64 {
+	return r.r.max
 }
 
 // NewReader makes a simple reader that sits on the other end
@@ -192,7 +191,7 @@ func NewReader(r io.Reader) (*Reader, error) {
 	return &Reader{r: r, max: max}, nil
 }
 
-// Read reads a point from the underyling reader and
+// Read reads a point from the underlying reader and
 // write it into p. Returns io.EOF when
 // the sequence has been completely read.
 func (r *Reader) Read(point *[EncodedLen]byte) (err error) {
@@ -211,8 +210,8 @@ func (r *Reader) Read(point *[EncodedLen]byte) (err error) {
 
 // Max returns the expected number of matchable
 // this decoder will receive
-func (dec *Reader) Max() int64 {
-	return dec.max
+func (r *Reader) Max() int64 {
+	return r.max
 }
 
 // init the permutations slice matrix
@@ -221,11 +220,11 @@ func initP(n int64) []int64 {
 	var max = big.NewInt(n - 1)
 	// Chooses a uniform random int64
 	choose := func() int64 {
-		if i, err := rand.Int(rand.Reader, max); err == nil {
-			return i.Int64()
-		} else {
+		i, err := rand.Int(rand.Reader, max)
+		if err != nil {
 			return 0
 		}
+		return i.Int64()
 	}
 	// Initialize a trivial permutation
 	for i := int64(0); i < n; i++ {

--- a/pkg/dhpsi/dhpsi_parallel.go
+++ b/pkg/dhpsi/dhpsi_parallel.go
@@ -119,6 +119,8 @@ func (enc *DeriveMultiplyParallelShuffler) Permutations() permutations.Permutati
 // up the buffers and block on submitting
 // the work
 
+// A MultiplyParallelReader is a reader that sits on the other end of a DeriveMultiplyShuffler
+// or a Writer and reads encoded ristretto hashes and multiplies them using gr.
 type MultiplyParallelReader struct {
 	r   *Reader
 	seq int64
@@ -232,7 +234,7 @@ func fill(r *Reader, gr Ristretto) <-chan [EncodedLen]byte {
 		for b := range batches {
 			// if this is the current batch, write it out
 			if sent == b.n {
-				copy_out(b, c, closed)
+				copyOut(b, c, closed)
 				sent++
 			} else {
 				// buffer it
@@ -241,7 +243,7 @@ func fill(r *Reader, gr Ristretto) <-chan [EncodedLen]byte {
 			// check if buffered
 			if b, ok := ring[sent]; ok {
 				// do we have it buffered?
-				copy_out(b, c, closed)
+				copyOut(b, c, closed)
 				delete(ring, sent)
 				sent++
 			}
@@ -250,14 +252,14 @@ func fill(r *Reader, gr Ristretto) <-chan [EncodedLen]byte {
 		// flush out the rest of the buffer
 		for i := 0; i < len(ring); i++ {
 			b := ring[sent+i]
-			copy_out(b, c, closed)
+			copyOut(b, c, closed)
 		}
 	}()
 
 	return c
 }
 
-func copy_out(b mBatch, c chan [EncodedLen]byte, done chan bool) (n int64) {
+func copyOut(b mBatch, c chan [EncodedLen]byte, done chan bool) (n int64) {
 	for _, point := range b.points {
 		select {
 		case c <- point:
@@ -269,7 +271,7 @@ func copy_out(b mBatch, c chan [EncodedLen]byte, done chan bool) (n int64) {
 	return
 }
 
-// Read reads a point from the underyling reader, multiply it with ristretto
+// Read reads a point from the underlying reader, multiply it with ristretto
 // and write it into point. Returns io.EOF when
 // the sequence has been completely read.
 func (dec *MultiplyParallelReader) Read(point *[EncodedLen]byte) (err error) {

--- a/pkg/dhpsi/dhpsi_parallel_test.go
+++ b/pkg/dhpsi/dhpsi_parallel_test.go
@@ -149,7 +149,7 @@ func TestMultiplyParallelReader(t *testing.T) {
 	default:
 	}
 
-	// same received and sent lenght?
+	// same received and sent length?
 	if len(sent) != len(received) {
 		t.Errorf("sent (%d) and received (%d) len not equal", len(sent), len(received))
 	}

--- a/pkg/dhpsi/sender.go
+++ b/pkg/dhpsi/sender.go
@@ -45,20 +45,20 @@ func (s *Sender) Send(ctx context.Context, n int64, identifiers <-chan []byte) e
 	gr, _ := NewRistretto(RistrettoTypeR255)
 	// stage1 : writes the permutated identifiers to the receiver
 	stage1 := func() error {
-		if writer, err := NewDeriveMultiplyParallelShuffler(s.rw, n, gr); err != nil {
+		writer, err := NewDeriveMultiplyParallelShuffler(s.rw, n, gr)
+		if err != nil {
 			return err
-		} else {
-			// read N matchables from r
-			// and write them to stage1
-			// shuffle will error out if more than N
-			// are read from identifiers
-			for identifier := range identifiers {
-				if err := writer.Shuffle(identifier); err != nil {
-					return err
-				}
-			}
-			return nil
 		}
+		// read N matchables from r
+		// and write them to stage1
+		// shuffle will error out if more than N
+		// are read from identifiers
+		for identifier := range identifiers {
+			if err := writer.Shuffle(identifier); err != nil {
+				return err
+			}
+		}
+		return nil
 	}
 
 	// stage2 : reads the identifiers from the receiver, encrypt them and send them back
@@ -67,22 +67,22 @@ func (s *Sender) Send(ctx context.Context, n int64, identifiers <-chan []byte) e
 		if err != nil {
 			return err
 		}
-		if writer, err := NewWriter(s.rw, reader.Max()); err != nil {
+		writer, err := NewWriter(s.rw, reader.Max())
+		if err != nil {
 			return err
-		} else {
-			for i := int64(0); i < reader.Max(); i++ {
-				var p [EncodedLen]byte
-				if err := reader.Read(&p); err != nil {
-					if err != io.EOF {
-						return err
-					}
-				}
-				if err := writer.Write(p); err != nil {
-					return fmt.Errorf("stage2: %v", err)
+		}
+		for i := int64(0); i < reader.Max(); i++ {
+			var p [EncodedLen]byte
+			if err := reader.Read(&p); err != nil {
+				if err != io.EOF {
+					return err
 				}
 			}
-			return nil
+			if err := writer.Write(p); err != nil {
+				return fmt.Errorf("stage2: %v", err)
+			}
 		}
+		return nil
 	}
 
 	// run stage1

--- a/pkg/npsi/sender.go
+++ b/pkg/npsi/sender.go
@@ -45,21 +45,21 @@ func (s *Sender) Send(ctx context.Context, n int64, identifiers <-chan []byte) e
 	// stage 2: send hashes salted with K to P1
 	stage2 := func() error {
 		// get a hasher
-		if h, err := hash.New(hash.Highway, k); err != nil {
+		h, err := hash.New(hash.Highway, k)
+		if err != nil {
 			return err
-		} else {
-			// inform the receiver of the size
-			// its about to receive
-			if err := binary.Write(s.rw, binary.BigEndian, &n); err != nil {
-				return err
-			}
-			// make a channel to receive local x,h pairs
-			sender := HashAllParallel(h, identifiers)
-			// exhaust the hashes into the receiver
-			for hash := range sender {
-				if err := HashWrite(s.rw, hash.h); err != nil {
-					return fmt.Errorf("stage2: %v", err)
-				}
+		}
+		// inform the receiver of the size
+		// its about to receive
+		if err := binary.Write(s.rw, binary.BigEndian, &n); err != nil {
+			return err
+		}
+		// make a channel to receive local x,h pairs
+		sender := HashAllParallel(h, identifiers)
+		// exhaust the hashes into the receiver
+		for hash := range sender {
+			if err := HashWrite(s.rw, hash.h); err != nil {
+				return fmt.Errorf("stage2: %v", err)
 			}
 		}
 		return nil

--- a/test/psi/types_test.go
+++ b/test/psi/types_test.go
@@ -7,7 +7,7 @@ type test_size struct {
 }
 
 // test scenarios
-// the common part will be substracted from the sender &
+// the common part will be subtracted from the sender &
 // the receiver len, so for instance
 //
 //  100 common, 100 sender will result in the sender len being 100 and only


### PR DESCRIPTION
Fixed misspellings and linter errors listed here: https://goreportcard.com/report/github.com/optable/match

I largely did not add additional comments to exported const/vars/types/functions.