### PR TITLE
Optimize stage3

### DIFF
--- a/examples/receiver/main.go
+++ b/examples/receiver/main.go
@@ -35,7 +35,7 @@ var out *string
 
 func main() {
 	var wg sync.WaitGroup
-	var protocol = flag.String("proto", defaultProtocol, "the psi protocol (dhpsi,npsi)")
+	var protocol = flag.String("proto", defaultProtocol, "the psi protocol (bpsi,npsi,dhpsi,kkrt)")
 	var port = flag.String("p", defaultPort, "The receiver port")
 	var file = flag.String("in", defaultSenderFileName, "A list of IDs terminated with a newline")
 	out = flag.String("out", defaultCommonFileName, "A list of IDs that intersect between the receiver and the sender")

--- a/examples/sender/main.go
+++ b/examples/sender/main.go
@@ -29,7 +29,7 @@ func showUsageAndExit(exitcode int) {
 }
 
 func main() {
-	var protocol = flag.String("proto", defaultProtocol, "the psi protocol (dhpsi,npsi)")
+	var protocol = flag.String("proto", defaultProtocol, "the psi protocol (bpsi,npsi,dhpsi,kkrt)")
 	var addr = flag.String("a", defaultAddress, "The receiver address")
 	var file = flag.String("in", defaultSenderFileName, "A list of IDs terminated with a newline")
 	var showHelp = flag.Bool("h", false, "Show help message")

--- a/internal/crypto/crypto.go
+++ b/internal/crypto/crypto.go
@@ -33,8 +33,7 @@ const (
 // secretKey is a 16 byte slice for AES-128
 // k is the desired number of bytes
 // on success, pseudorandomCode returns a byte slice of length k.
-func PseudorandomCode(secretKey []byte, k int, src []byte) []byte {
-	block, _ := aes.NewCipher(secretKey)
+func PseudorandomCode(aesBlock cipher.Block, k int, src []byte) []byte {
 	tmp := make([]byte, aes.BlockSize*4)
 	dst := make([]byte, aes.BlockSize*4*8)
 
@@ -42,10 +41,10 @@ func PseudorandomCode(secretKey []byte, k int, src []byte) []byte {
 	src = pad(src)
 
 	// encrypt
-	block.Encrypt(tmp[:aes.BlockSize], append([]byte{1}, src...))
-	block.Encrypt(tmp[aes.BlockSize:aes.BlockSize*2], append([]byte{2}, src...))
-	block.Encrypt(tmp[aes.BlockSize*2:aes.BlockSize*3], append([]byte{3}, src...))
-	block.Encrypt(tmp[aes.BlockSize*3:], append([]byte{4}, src...))
+	aesBlock.Encrypt(tmp[:aes.BlockSize], append([]byte{1}, src...))
+	aesBlock.Encrypt(tmp[aes.BlockSize:aes.BlockSize*2], append([]byte{2}, src...))
+	aesBlock.Encrypt(tmp[aes.BlockSize*2:aes.BlockSize*3], append([]byte{3}, src...))
+	aesBlock.Encrypt(tmp[aes.BlockSize*3:], append([]byte{4}, src...))
 
 	// extract pseudorandom bytes to bits
 	util.ExtractBytesToBits(tmp, dst)

--- a/internal/cuckoo/cuckoo.go
+++ b/internal/cuckoo/cuckoo.go
@@ -28,8 +28,8 @@ func init() {
 // the hash function used to compute which bucket index
 // the item is inserted in.
 type value struct {
-	item []byte
 	hIdx uint8
+	item []byte
 }
 
 func (v value) Empty() bool {
@@ -143,7 +143,7 @@ func (c *Cuckoo) tryAdd(item []byte, bucketIndices [Nhash]uint64, ignore bool, e
 
 		if c.buckets[bIdx].Empty() {
 			// this is a free slot
-			c.buckets[bIdx] = value{item, uint8(hIdx)}
+			c.buckets[bIdx] = value{uint8(hIdx), item}
 			return true
 		}
 	}
@@ -160,7 +160,7 @@ func (c *Cuckoo) tryGreedyAdd(item []byte, bucketIndices [Nhash]uint64) (homeLes
 		evictedBIdx := bucketIndices[evictedHIdx]
 		evictedItem := c.buckets[evictedBIdx]
 		// insert the item in the evicted slot
-		c.buckets[evictedBIdx] = value{item, uint8(evictedHIdx)}
+		c.buckets[evictedBIdx] = value{uint8(evictedHIdx), item}
 
 		evictedBucketIndices := c.BucketIndices(evictedItem.item)
 		// try to reinsert the evicted items

--- a/internal/cuckoo/cuckoo.go
+++ b/internal/cuckoo/cuckoo.go
@@ -255,14 +255,16 @@ func (v *value) GetHashIdx() uint8 {
 	return v.hIdx
 }
 
-func (c *Cuckoo) Bucket() []value {
-	if c.buckets != nil {
-		clone := make([]value, len(c.buckets))
-		copy(clone, c.buckets)
-		return clone
-	} else {
-		return nil
-	}
+func (c *Cuckoo) Bucket() <-chan value {
+	var valueChan = make(chan value, c.bucketSize)
+	go func() {
+		for _, v := range c.buckets {
+			valueChan <- v
+		}
+		close(valueChan)
+	}()
+
+	return valueChan
 }
 
 func (c *Cuckoo) BucketSize() int {

--- a/internal/cuckoo/cuckoo.go
+++ b/internal/cuckoo/cuckoo.go
@@ -238,11 +238,14 @@ func (v *value) oprfInput() []byte {
 // if the identifier is in the bucket, it appends the hash index
 // if the identifier is on stash, it returns just the id
 // if the bucket has nothing it in, it returns a dummy value: 255
-func (c *Cuckoo) OPRFInput() [][]byte {
-	r := make([][]byte, c.Len())
-	for i, b := range c.buckets {
-		r[i] = b.oprfInput()
-	}
+func (c *Cuckoo) OPRFInput() <-chan []byte {
+	r := make(chan []byte, c.Len())
+	go func() {
+		for _, b := range c.buckets {
+			r <- b.oprfInput()
+		}
+		close(r)
+	}()
 
 	return r
 }

--- a/internal/cuckoo/cuckoo_test.go
+++ b/internal/cuckoo/cuckoo_test.go
@@ -84,13 +84,6 @@ func BenchmarkCuckooInsert(b *testing.B) {
 	}
 }
 
-func BenchmarkBucketIndicesPipeline(b *testing.B) {
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		bench_cuckoo.BucketIndices(benchData[i%int(bench_n)])
-	}
-}
-
 // Benchmark find hash index
 func BenchmarkCuckooGetHashIdx(b *testing.B) {
 	b.ResetTimer()

--- a/internal/oprf/improved_kkrt.go
+++ b/internal/oprf/improved_kkrt.go
@@ -128,8 +128,6 @@ func (ext imprvKKRT) Receive(choices [][]byte, rw io.ReadWriter) (t [][]byte, er
 		pseudorandomChan <- util.Transpose(d)
 	}()
 
-	// Receive pseudorandom msg from bitSliceChan
-
 	// sample k x k bit mtrix
 	seeds, err := util.SampleRandomBitMatrix(ext.prng, 2*ext.k, ext.k)
 	if err != nil {

--- a/internal/oprf/kkrt.go
+++ b/internal/oprf/kkrt.go
@@ -13,6 +13,7 @@ Receive returns the OPRF evaluated on inputs using the key: OPRF(k, r)
 */
 
 import (
+	"crypto/aes"
 	crand "crypto/rand"
 	"encoding/binary"
 	"io"
@@ -112,8 +113,9 @@ func (o kkrt) Receive(choices [][]byte, rw io.ReadWriter) (t [][]byte, err error
 	var pseudorandomChan = make(chan [][]byte)
 	go func() {
 		d := make([][]byte, o.m)
+		aesBlock, _ := aes.NewCipher(sk)
 		for i := 0; i < o.m; i++ {
-			d[i] = crypto.PseudorandomCode(sk, o.k, choices[i])
+			d[i] = crypto.PseudorandomCode(aesBlock, o.k, choices[i])
 		}
 		pseudorandomChan <- util.Transpose(d)
 	}()
@@ -149,7 +151,8 @@ func (o kkrt) Receive(choices [][]byte, rw io.ReadWriter) (t [][]byte, err error
 // Encode computes and returns OPRF(k, in)
 func (o kkrt) Encode(k Key, in []byte) (out []byte, err error) {
 	// compute q_i ^ (C(r) & s)
-	out, err = util.AndBytes(crypto.PseudorandomCode(k.sk, o.k, in), k.s)
+	aesBlock, _ := aes.NewCipher(k.sk)
+	out, err = util.AndBytes(crypto.PseudorandomCode(aesBlock, o.k, in), k.s)
 	if err != nil {
 		return
 	}

--- a/internal/oprf/kkrt.go
+++ b/internal/oprf/kkrt.go
@@ -108,6 +108,7 @@ func (o kkrt) Receive(choices [][]byte, rw io.ReadWriter) (t [][]byte, err error
 		return nil, err
 	}
 
+	// compute code word using pseudorandom code on choice stirng r in a separate thread
 	var pseudorandomChan = make(chan [][]byte)
 	go func() {
 		d := make([][]byte, o.m)

--- a/internal/oprf/kkrt.go
+++ b/internal/oprf/kkrt.go
@@ -158,15 +158,12 @@ func (o kkrt) Receive(choices [][]byte, rw io.ReadWriter) (t [][]byte, err error
 // Encode computes and returns OPRF(k, in)
 func (o kkrt) Encode(k Key, in []byte) (out []byte, err error) {
 	// compute q_i ^ (C(r) & s)
-	x, err := util.AndBytes(crypto.PseudorandomCode(k.sk, o.k, in), k.s)
+	out, err = util.AndBytes(crypto.PseudorandomCode(k.sk, o.k, in), k.s)
 	if err != nil {
 		return
 	}
 
-	t, err := util.XorBytes(k.q, x)
-	if err != nil {
-		return
-	}
+	err = util.InPlaceXorBytes(k.q, out)
 
-	return t, nil
+	return
 }

--- a/internal/oprf/oprf_test.go
+++ b/internal/oprf/oprf_test.go
@@ -14,7 +14,7 @@ import (
 var (
 	network   = "tcp"
 	address   = "127.0.0.1:"
-	baseCount = 1000
+	baseCount = 100000
 	prng      = rand.New(rand.NewSource(time.Now().UnixNano()))
 	choices   = genChoiceString()
 )

--- a/internal/ot/improved_iknp_nco.go
+++ b/internal/ot/improved_iknp_nco.go
@@ -1,6 +1,7 @@
 package ot
 
 import (
+	"crypto/aes"
 	"fmt"
 	"io"
 	"math/rand"
@@ -134,8 +135,9 @@ func (ext imprvIKNPNCO) Receive(choices []uint8, messages [][]byte, rw io.ReadWr
 
 	// compute code word using pseudorandom code on choice stirng r
 	c := make([][]byte, ext.k)
+	aesBlock, _ := aes.NewCipher(sk)
 	for row := range c {
-		c[row] = crypto.PseudorandomCode(sk, ext.k, []byte{byte(row)})
+		c[row] = crypto.PseudorandomCode(aesBlock, ext.k, []byte{byte(row)})
 		if _, err := rw.Write(c[row]); err != nil {
 			return err
 		}

--- a/internal/ot/improved_kkrt.go
+++ b/internal/ot/improved_kkrt.go
@@ -84,10 +84,10 @@ func (ext imprvKKRT) Send(messages [][][]byte, rw io.ReadWriter) (err error) {
 
 	// encrypt messages and send them
 	var key, ciphertext, x []byte
+	aesBlock, _ := aes.NewCipher(sk)
 	for i := range messages {
 		for choice, plaintext := range messages[i] {
 			// compute q_i ^ (C(r) & s)
-			aesBlock, _ := aes.NewCipher(sk)
 			x, _ = util.AndBytes(crypto.PseudorandomCode(aesBlock, ext.k, []byte{byte(choice)}), s)
 			key, _ = util.XorBytes(q[i], x)
 

--- a/internal/ot/improved_kkrt.go
+++ b/internal/ot/improved_kkrt.go
@@ -1,6 +1,7 @@
 package ot
 
 import (
+	"crypto/aes"
 	"fmt"
 	"io"
 	"math/rand"
@@ -86,7 +87,8 @@ func (ext imprvKKRT) Send(messages [][][]byte, rw io.ReadWriter) (err error) {
 	for i := range messages {
 		for choice, plaintext := range messages[i] {
 			// compute q_i ^ (C(r) & s)
-			x, _ = util.AndBytes(crypto.PseudorandomCode(sk, ext.k, []byte{byte(choice)}), s)
+			aesBlock, _ := aes.NewCipher(sk)
+			x, _ = util.AndBytes(crypto.PseudorandomCode(aesBlock, ext.k, []byte{byte(choice)}), s)
 			key, _ = util.XorBytes(q[i], x)
 
 			ciphertext, err = crypto.Encrypt(iknpCipherMode, key, uint8(choice), plaintext)
@@ -117,8 +119,9 @@ func (ext imprvKKRT) Receive(choices []uint8, messages [][]byte, rw io.ReadWrite
 
 	// compute code word using pseudorandom code on choice stirng r
 	d := make([][]byte, ext.m)
+	aesBlock, _ := aes.NewCipher(sk)
 	for row := range d {
-		d[row] = crypto.PseudorandomCode(sk, ext.k, []byte{choices[row]})
+		d[row] = crypto.PseudorandomCode(aesBlock, ext.k, []byte{choices[row]})
 	}
 
 	d = util.Transpose(d)

--- a/internal/ot/kkrt.go
+++ b/internal/ot/kkrt.go
@@ -12,6 +12,7 @@ Reference:	https://eprint.iacr.org/2013/491.pdf (Improved IKNP)
 */
 
 import (
+	"crypto/aes"
 	"fmt"
 	"io"
 	"math/rand"
@@ -80,11 +81,12 @@ func (ext kkrt) Send(messages [][][]byte, rw io.ReadWriter) (err error) {
 
 	var key, x, ciphertext []byte
 	// encrypt messages and send them
+	aesBlock, _ := aes.NewCipher(sk)
 	for i := range messages {
 		// proof of concept, suppose we have n messages, and the choice string is an integer in [1, ..., n]
 		for choice, plaintext := range messages[i] {
 			// compute q_i ^ (C(r) & s)
-			x, _ = util.AndBytes(crypto.PseudorandomCode(sk, ext.k, []byte{byte(choice)}), s)
+			x, _ = util.AndBytes(crypto.PseudorandomCode(aesBlock, ext.k, []byte{byte(choice)}), s)
 			key, _ = util.XorBytes(q[i], x)
 
 			ciphertext, err = crypto.Encrypt(kkrtCipherMode, key, uint8(choice), plaintext)
@@ -123,12 +125,14 @@ func (ext kkrt) Receive(choices []uint8, messages [][]byte, rw io.ReadWriter) (e
 	var wg sync.WaitGroup
 	// make m pairs of k bytes baseOT messages: {t_i, t_i xor C(choices[i])}
 	baseMsgs := make([][][]byte, ext.m)
+	aesBlock, _ := aes.NewCipher(sk)
 	for i := range baseMsgs {
 		wg.Add(1)
 		go func(i int, msg chan<- []byte) {
 			defer wg.Done()
 			msg <- t[i]
-			m2, err := util.XorBytes(t[i], crypto.PseudorandomCode(sk, ext.k, []byte{choices[i]}))
+
+			m2, err := util.XorBytes(t[i], crypto.PseudorandomCode(aesBlock, ext.k, []byte{choices[i]}))
 			msg <- m2
 			if err != nil {
 				errBus <- err

--- a/internal/util/bits.go
+++ b/internal/util/bits.go
@@ -10,7 +10,7 @@ var ErrByteLengthMissMatch = fmt.Errorf("provided bytes do not have the same len
 // XorBytes xors each byte from a with b and returns dst
 // if a and b are the same length
 func XorBytes(a, b []byte) (dst []byte, err error) {
-	n := len(b)
+	var n = len(b)
 	if n != len(a) {
 		return nil, ErrByteLengthMissMatch
 	}
@@ -27,11 +27,12 @@ func XorBytes(a, b []byte) (dst []byte, err error) {
 // Inplace XorBytes xors each byte from a with b and returns dst
 // if a and b are the same length
 func InPlaceXorBytes(a, dst []byte) error {
-	if len(dst) != len(a) {
+	var n = len(dst)
+	if n != len(a) {
 		return ErrByteLengthMissMatch
 	}
 
-	for i := range dst {
+	for i := 0; i < n; i++ {
 		dst[i] = a[i] ^ dst[i]
 	}
 

--- a/internal/util/bits.go
+++ b/internal/util/bits.go
@@ -138,8 +138,8 @@ func SampleRandomBitMatrix(r *rand.Rand, m, k int) ([][]uint8, error) {
 
 // SampleBitSlice returns a slice of uint8 of pseudorandom bits
 func SampleBitSlice(prng *rand.Rand, b []uint8) (err error) {
-	// read up to len(b) pseudorandom bits
-	t := make([]byte, len(b)/8)
+	// read up to len(b) + 1 pseudorandom bits
+	t := make([]byte, len(b)/8+1)
 	if _, err = prng.Read(t); err != nil {
 		return nil
 	}
@@ -153,12 +153,12 @@ func SampleBitSlice(prng *rand.Rand, b []uint8) (err error) {
 // ExtractBytesToBits returns a byte array of bits from src
 // if len(dst) < len(src) * 8, nothing will be done
 func ExtractBytesToBits(src, dst []byte) {
-	if len(dst) < len(src)*8 {
+	if len(dst) > len(src)*8 {
 		return
 	}
 
 	var i int
-	for _, _byte := range src {
+	for _, _byte := range src[:len(src)-1] {
 		dst[i] = uint8(_byte & 0x01)
 		dst[i+1] = uint8((_byte >> 1) & 0x01)
 		dst[i+2] = uint8((_byte >> 2) & 0x01)
@@ -168,5 +168,10 @@ func ExtractBytesToBits(src, dst []byte) {
 		dst[i+6] = uint8((_byte >> 6) & 0x01)
 		dst[i+7] = uint8((_byte >> 7) & 0x01)
 		i += 8
+	}
+
+	// handle the last byte
+	for i = 0; i < len(dst)%8; i++ {
+		dst[(len(src)-1)*8+i] = uint8((src[len(src)-1] >> i) & 0x01)
 	}
 }

--- a/internal/util/bits.go
+++ b/internal/util/bits.go
@@ -24,6 +24,20 @@ func XorBytes(a, b []byte) (dst []byte, err error) {
 	return
 }
 
+// Inplace XorBytes xors each byte from a with b and returns dst
+// if a and b are the same length
+func InPlaceXorBytes(a, dst []byte) error {
+	if len(dst) != len(a) {
+		return ErrByteLengthMissMatch
+	}
+
+	for i := range dst {
+		dst[i] = a[i] ^ dst[i]
+	}
+
+	return nil
+}
+
 // AndBytes returns the binary and of each byte in a and b
 // if a and b are the same length
 func AndBytes(a, b []byte) (dst []byte, err error) {
@@ -41,6 +55,20 @@ func AndBytes(a, b []byte) (dst []byte, err error) {
 	return
 }
 
+// InplaceAndBytes returns the binary and of each byte in a and b
+// if a and b are the same length
+func InPlaceAndBytes(a, dst []byte) error {
+	if len(dst) != len(a) {
+		return ErrByteLengthMissMatch
+	}
+
+	for i := range dst {
+		dst[i] = a[i] & dst[i]
+	}
+
+	return nil
+}
+
 func AndByte(a uint8, b []byte) (dst []byte) {
 	dst = make([]byte, len(b))
 
@@ -49,6 +77,12 @@ func AndByte(a uint8, b []byte) (dst []byte) {
 	}
 
 	return
+}
+
+func InPlaceAndByte(a uint8, dst []byte) {
+	for i := range dst {
+		dst[i] = a & dst[i]
+	}
 }
 
 // Transpose returns the transpose of a 2D slices of uint8

--- a/internal/util/bits_test.go
+++ b/internal/util/bits_test.go
@@ -64,6 +64,7 @@ func BenchmarkXorBytes(b *testing.B) {
 func BenchmarkInplaceXorBytes(b *testing.B) {
 	a := make([]byte, 10000)
 	SampleBitSlice(prng, a)
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		InPlaceXorBytes(a, a)
 	}

--- a/internal/util/bits_test.go
+++ b/internal/util/bits_test.go
@@ -51,3 +51,20 @@ func BenchmarkSampleBitMatrix(b *testing.B) {
 		SampleRandomBitMatrix(prng, 10000, 424)
 	}
 }
+
+func BenchmarkXorBytes(b *testing.B) {
+	a := make([]byte, 10000)
+	SampleBitSlice(prng, a)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		XorBytes(a, a)
+	}
+}
+
+func BenchmarkInplaceXorBytes(b *testing.B) {
+	a := make([]byte, 10000)
+	SampleBitSlice(prng, a)
+	for i := 0; i < b.N; i++ {
+		InPlaceXorBytes(a, a)
+	}
+}

--- a/pkg/kkrtpsi/receiver.go
+++ b/pkg/kkrtpsi/receiver.go
@@ -139,7 +139,7 @@ func (r *Receiver) Intersect(ctx context.Context, n int64, identifiers <-chan []
 		}
 
 		// read cuckoo.Nhash number of hastable table of encoded remote IDs
-		var remoteHashtables = make([]map[uint64]bool, cuckoo.Nhash)
+		var remoteHashtables [cuckoo.Nhash]map[uint64]bool
 		for i := range remoteHashtables {
 			var u uint64
 			// read encoded id and insert

--- a/pkg/kkrtpsi/receiver.go
+++ b/pkg/kkrtpsi/receiver.go
@@ -96,7 +96,7 @@ func (r *Receiver) Intersect(ctx context.Context, n int64, identifiers <-chan []
 			return err
 		}
 
-		oReceiver, err := oprf.NewImprovedKKRT(int(oprfInputSize), oprfOutputSize, ot.Simplest, false)
+		oReceiver, err := oprf.NewKKRT(int(oprfInputSize), oprfOutputSize, ot.Simplest, false)
 		if err != nil {
 			return err
 		}

--- a/pkg/kkrtpsi/sender.go
+++ b/pkg/kkrtpsi/sender.go
@@ -51,7 +51,7 @@ func (s *Sender) Send(ctx context.Context, n int64, identifiers <-chan []byte) (
 
 	var oSender oprf.OPRF
 	var oprfKeys []oprf.Key
-	var hashedIds = make(chan hashable)
+	var hashedIds = make(chan hashable, n)
 
 	// stage 1: sample 3 hash seeds and write them to receiver
 	// for cuckoo hashing parameters agreement.

--- a/pkg/kkrtpsi/sender.go
+++ b/pkg/kkrtpsi/sender.go
@@ -118,7 +118,7 @@ func (s *Sender) Send(ctx context.Context, n int64, identifiers <-chan []byte) (
 			return err
 		}
 
-		var hashtable = make([]chan uint64, cuckoo.Nhash)
+		var hashtable [cuckoo.Nhash]chan uint64
 
 		hasher, err := hash.New(hash.Highway, seeds[0])
 		if err != nil {

--- a/pkg/kkrtpsi/sender.go
+++ b/pkg/kkrtpsi/sender.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"math/rand"
 	"sync"
-	"time"
 
 	"github.com/optable/match/internal/cuckoo"
 	"github.com/optable/match/internal/hash"
@@ -57,9 +56,6 @@ func (s *Sender) Send(ctx context.Context, n int64, identifiers <-chan []byte) (
 	// for cuckoo hashing parameters agreement.
 	// read local ids and store the potential bucket indexes for each id.
 	stage1 := func() error {
-		// seed randomness
-		rand.Seed(time.Now().UnixNano())
-
 		// sample Nhash hash seeds
 		for i := range seeds {
 			seeds[i] = make([]byte, hash.SaltLength)
@@ -98,7 +94,7 @@ func (s *Sender) Send(ctx context.Context, n int64, identifiers <-chan []byte) (
 		}
 
 		// instantiate OPRF sender with agreed parameters
-		oSender, err = oprf.NewImprovedKKRT(int(oprfInputSize), findK(oprfInputSize), ot.Simplest, false)
+		oSender, err = oprf.NewKKRT(int(oprfInputSize), findK(oprfInputSize), ot.Simplest, false)
 		if err != nil {
 			return err
 		}

--- a/test/psi/receiver_test.go
+++ b/test/psi/receiver_test.go
@@ -190,7 +190,7 @@ func TestKKRTReceiver(t *testing.T) {
 		// generate common data
 		common := emails.Common(s.commonLen)
 		// test
-		if err := testReceiver(psi.KKRTPSI, common, s, false); err != nil {
+		if err := testReceiver(psi.KKRTPSI, common, s, true); err != nil {
 			t.Fatalf("%s: %v", s.scenario, err)
 		}
 	}

--- a/test/psi/types_test.go
+++ b/test/psi/types_test.go
@@ -20,5 +20,5 @@ var test_sizes = []test_size{
 	{"sameSize", 100, 100, 100},
 	{"smallSize", 100, 10000, 1000},
 	{"mediumSize", 1000, 100000, 10000},
-	{"bigSize", 10000, 100000, 10000},
+	{"bigSize", 10000, 100000, 100000},
 }


### PR DESCRIPTION
* use `crypto/rand` for key materials
* fix `util.ExtractBytesToBits` to handle last byte even if it does not fit into 1 byte
* remove 3D matrix transposition in KKRT oprf which leads to similar performance as the improvedKKRT OPRF
* Use KKRT oprf instead in the KKRT PSI protocol
* cuckoo returns channels
* use in place `XOR` and `AND` operations to avoid reallocations.