### PR TITLE
Optimize stage3

### DIFF
--- a/internal/crypto/crypto.go
+++ b/internal/crypto/crypto.go
@@ -1,7 +1,6 @@
 package crypto
 
 import (
-	"bytes"
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
@@ -10,7 +9,6 @@ import (
 	"github.com/optable/match/internal/util"
 	"github.com/zeebo/blake3"
 	"golang.org/x/crypto/blake2b"
-	"golang.org/x/crypto/sha3"
 )
 
 /*
@@ -18,11 +16,9 @@ Various cipher suite implementation in golang
 */
 
 const (
-	CTR = iota
-	GCM
+	GCM = iota
 	XORBlake2
 	XORBlake3
-	XORShake
 
 	nonceSize = 12 //aesgcm NonceSize
 )
@@ -59,7 +55,7 @@ func PseudorandomCode(secretKey, src []byte) (dst []byte) {
 func pad(src []byte) (tmp []byte) {
 	tmp = make([]byte, len(src)+aes.BlockSize-len(src)%aes.BlockSize)
 	copy(tmp[1:], src)
-	return tmp
+	return
 }
 
 // H(seed) xor src, where H is modeled as a pseudorandom generator.
@@ -87,37 +83,10 @@ func PseudorandomGeneratorWithBlake3(s *blake3.Hasher, seed []byte, length int) 
 	return dst[:length]
 }
 
-// aes gcm(seed, src)
-func pseudorandomGeneratorWithAESGCM(gcm cipher.AEAD, seed []byte, length int) (dst []byte, err error) {
-	seed = append(seed, bytes.Repeat(seed, (length+7)/8/len(seed)+1)...)
-	tmp := gcm.Seal(nil, seed[:nonceSize], seed, nil)
-	dst = make([]byte, length)
-	// extract pseudorandom bytes to bits
-	util.ExtractBytesToBits(tmp, dst)
-	return
-}
-
-func xorCipherWithAESCTR(block cipher.Block, seed []byte, src []byte) (dst []byte, err error) {
-	dst = make([]byte, len(src))
-	iv := seed[:aes.BlockSize]
-	stream := cipher.NewCTR(block, iv)
-	stream.XORKeyStream(dst, src)
-	return
-}
-
-func xorCipherWithAESCTR2(block cipher.Block, seed []byte, src []byte) (dst []byte, err error) {
-	dst = make([]byte, len(src))
-	h := blake3.Sum256(seed)
-	iv, _ := util.XorBytes(h[:16], h[16:])
-	stream := cipher.NewCTR(block, iv)
-	stream.XORKeyStream(dst, src)
-	return
-}
-
 // Blake3 has XOF which is perfect for doing xor cipher.
-func xorCipherWithBlake3(key []byte, ind uint8, src []byte) (dst []byte, err error) {
+func xorCipherWithBlake3(key []byte, ind uint8, src []byte) ([]byte, error) {
 	hash := make([]byte, len(src))
-	err = getBlake3Hash(key, ind, hash)
+	err := getBlake3Hash(key, ind, hash)
 	if err != nil {
 		return nil, err
 	}
@@ -132,32 +101,14 @@ func getBlake3Hash(key []byte, ind uint8, dst []byte) error {
 	// convert to *digest to take a snapshot of the hashstate for XOF
 	d := h.Digest()
 	_, err := d.Read(dst)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// Shake from the Sha3 family has XOF which is perfect for doing xor cipher.
-func xorCipherWithShake(key []byte, ind uint8, src []byte) (dst []byte, err error) {
-	hash := make([]byte, len(src))
-	getShakeHash(key, ind, hash)
-	return util.XorBytes(hash, src)
-}
-
-func getShakeHash(key []byte, ind uint8, dst []byte) {
-	h := sha3.NewShake256()
-	h.Write(key)
-	h.Write([]byte{ind})
-	h.Read(dst)
+	return err
 }
 
 // xorCipher returns the result of H(ind, key) XOR src
 // note that encrypt and decrypt in XOR cipher are the same.
-func xorCipherWithBlake2(key []byte, ind uint8, src []byte) (dst []byte, err error) {
+func xorCipherWithBlake2(key []byte, ind uint8, src []byte) ([]byte, error) {
 	hash := make([]byte, len(src))
-	err = getBlake2Hash(key, ind, hash)
+	err := getBlake2Hash(key, ind, hash)
 	if err != nil {
 		return nil, err
 	}
@@ -176,52 +127,6 @@ func getBlake2Hash(key []byte, ind uint8, dst []byte) (err error) {
 	d.Write([]byte{ind})
 	d.Read(dst)
 
-	return
-}
-
-// aes CTR + HMAC encrypt decrypt
-func ctrEncrypt(key []byte, plaintext []byte) (ciphertext []byte, err error) {
-	block, err := aes.NewCipher(key)
-	if err != nil {
-		return nil, err
-	}
-
-	l := aes.BlockSize + len(plaintext)
-	ciphertext = make([]byte, l+32)
-	if _, err := rand.Read(ciphertext[:aes.BlockSize]); err != nil {
-		return nil, err
-	}
-
-	stream := cipher.NewCTR(block, ciphertext[:aes.BlockSize])
-	stream.XORKeyStream(ciphertext[aes.BlockSize:l], plaintext)
-
-	h := sha3.NewShake256()
-	// reuse IV as key for mac
-	h.Write(ciphertext[:aes.BlockSize])
-	h.Write(ciphertext[aes.BlockSize:l])
-	h.Read(ciphertext[l:])
-	return
-}
-
-func ctrDecrypt(key []byte, ciphertext []byte) (plaintext []byte, err error) {
-	block, err := aes.NewCipher(key)
-	if err != nil {
-		return nil, err
-	}
-	iv, c, mac := ciphertext[:aes.BlockSize], ciphertext[aes.BlockSize:len(ciphertext)-32], ciphertext[len(ciphertext)-32:]
-	plaintext = make([]byte, len(c))
-	stream := cipher.NewCTR(block, iv)
-
-	// verify mac
-	mac2 := make([]byte, 32)
-	h := sha3.NewShake256()
-	h.Write(iv)
-	h.Write(c)
-	h.Read(mac2)
-	if !bytes.Equal(mac, mac2) {
-		return nil, fmt.Errorf("cipher text is not authenticated")
-	}
-	stream.XORKeyStream(plaintext, c)
 	return
 }
 
@@ -269,16 +174,12 @@ func gcmDecrypt(key []byte, ciphertext []byte) (plaintext []byte, err error) {
 
 func Encrypt(mode int, key []byte, ind uint8, plaintext []byte) ([]byte, error) {
 	switch mode {
-	case CTR:
-		return ctrEncrypt(key, plaintext)
 	case GCM:
 		return gcmEncrypt(key, plaintext)
 	case XORBlake2:
 		return xorCipherWithBlake2(key, ind, plaintext)
 	case XORBlake3:
 		return xorCipherWithBlake3(key, ind, plaintext)
-	case XORShake:
-		return xorCipherWithShake(key, ind, plaintext)
 	}
 
 	return nil, fmt.Errorf("wrong encrypt mode")
@@ -286,16 +187,12 @@ func Encrypt(mode int, key []byte, ind uint8, plaintext []byte) ([]byte, error) 
 
 func Decrypt(mode int, key []byte, ind uint8, ciphertext []byte) ([]byte, error) {
 	switch mode {
-	case CTR:
-		return ctrDecrypt(key, ciphertext)
 	case GCM:
 		return gcmDecrypt(key, ciphertext)
 	case XORBlake2:
 		return xorCipherWithBlake2(key, ind, ciphertext)
 	case XORBlake3:
 		return xorCipherWithBlake3(key, ind, ciphertext)
-	case XORShake:
-		return xorCipherWithShake(key, ind, ciphertext)
 	}
 
 	return nil, fmt.Errorf("wrong decrypt mode")
@@ -304,11 +201,9 @@ func Decrypt(mode int, key []byte, ind uint8, ciphertext []byte) ([]byte, error)
 // compute ciphertext length in bytes
 func EncryptLen(mode int, msgLen int) int {
 	switch mode {
-	case CTR:
-		return aes.BlockSize + msgLen
 	case GCM:
 		return nonceSize + aes.BlockSize + msgLen
-	case XORBlake2, XORBlake3, XORShake:
+	case XORBlake2, XORBlake3:
 		fallthrough
 	default:
 		return msgLen

--- a/internal/crypto/crypto.go
+++ b/internal/crypto/crypto.go
@@ -35,25 +35,24 @@ const (
 // on success, pseudorandomCode returns a byte slice of length k.
 func PseudorandomCode(secretKey, src []byte) (dst []byte) {
 	aesBlock, _ := aes.NewCipher(secretKey)
-	tmp := make([]byte, aes.BlockSize*4)
-	dst = make([]byte, aes.BlockSize*4*8)
+	dst = make([]byte, aes.BlockSize*4*9)
 
 	// pad src
 	input := pad(src)
 	input[0] = 1
 
 	// encrypt
-	aesBlock.Encrypt(tmp[:aes.BlockSize], input)
+	aesBlock.Encrypt(dst[aes.BlockSize*32:aes.BlockSize*33], input)
 	input[0] = 2
-	aesBlock.Encrypt(tmp[aes.BlockSize:aes.BlockSize*2], input)
+	aesBlock.Encrypt(dst[aes.BlockSize*33:aes.BlockSize*34], input)
 	input[0] = 3
-	aesBlock.Encrypt(tmp[aes.BlockSize*2:aes.BlockSize*3], input)
+	aesBlock.Encrypt(dst[aes.BlockSize*34:aes.BlockSize*35], input)
 	input[0] = 4
-	aesBlock.Encrypt(tmp[aes.BlockSize*3:], input)
+	aesBlock.Encrypt(dst[aes.BlockSize*35:], input)
 
 	// extract pseudorandom bytes to bits
-	util.ExtractBytesToBits(tmp, dst)
-	return dst
+	util.ExtractBytesToBits(dst[aes.BlockSize*32:], dst[:aes.BlockSize*32])
+	return dst[:aes.BlockSize*32]
 }
 
 // pad aes block, with the first byte reserved for PseudorandomCode

--- a/internal/crypto/crypto.go
+++ b/internal/crypto/crypto.go
@@ -17,7 +17,6 @@ Various cipher suite implementation in golang
 
 const (
 	GCM = iota
-	XORBlake2
 	XORBlake3
 
 	nonceSize = 12 //aesgcm NonceSize
@@ -201,7 +200,7 @@ func EncryptLen(mode int, msgLen int) int {
 	switch mode {
 	case GCM:
 		return nonceSize + aes.BlockSize + msgLen
-	case XORBlake2, XORBlake3:
+	case XORBlake3:
 		fallthrough
 	default:
 		return msgLen

--- a/internal/crypto/crypto_test.go
+++ b/internal/crypto/crypto_test.go
@@ -17,12 +17,12 @@ var (
 	p      = []byte("example testing plaintext that holds important secrets: %QWEQW$##%Y^&%^*(*)&, []m")
 	aesKey = make([]byte, 16)
 	xorKey = make([]byte, len(p))
-	r      = rand.New(rand.NewSource(time.Now().UnixNano()))
+	prng   = rand.New(rand.NewSource(time.Now().UnixNano()))
 )
 
 func init() {
-	r.Read(aesKey)
-	r.Read(xorKey)
+	prng.Read(aesKey)
+	prng.Read(xorKey)
 }
 
 func BenchmarkSha(b *testing.B) {
@@ -146,10 +146,10 @@ func TestXORBlake3EncryptDecrypt(t *testing.T) {
 
 func TestXORBytes(t *testing.T) {
 	a := make([]byte, 32)
-	r.Read(a)
+	prng.Read(a)
 
 	b := make([]byte, 32)
-	r.Read(b)
+	prng.Read(b)
 	c, err := util.XorBytes(a, b)
 	if err != nil {
 		t.Fatal(err)
@@ -170,11 +170,20 @@ func TestXORBytes(t *testing.T) {
 
 func TestPseudorandomGeneratorWithBlake3(t *testing.T) {
 	seed := make([]byte, 424)
-	r.Read(seed)
+	prng.Read(seed)
 	n := 212
 	p := PseudorandomGeneratorWithBlake3(blake3.New(), seed, n)
 	if bytes.Equal(make([]byte, n), p) {
 		t.Fatalf("pseudorandom should not be 0")
+	}
+}
+
+func BenchmarkPseudorandomCode(b *testing.B) {
+	in := make([]byte, 64)
+	util.SampleBitSlice(prng, in)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		PseudorandomCode(aesKey, in)
 	}
 }
 

--- a/internal/crypto/crypto_test.go
+++ b/internal/crypto/crypto_test.go
@@ -51,31 +51,6 @@ func TestGCMEncrypDecrypt(t *testing.T) {
 	}
 }
 
-func TestXORBlake2EncryptDecrypt(t *testing.T) {
-	ciphertext, err := xorCipherWithBlake2(xorKey, 0, p)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	plain, err := Decrypt(XORBlake2, xorKey, 1, ciphertext)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if bytes.Equal(p, plain) {
-		t.Fatalf("decryption should not work!")
-	}
-
-	plain, err = xorCipherWithBlake2(xorKey, 0, ciphertext)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if !bytes.Equal(p, plain) {
-		t.Fatalf("Decryption should have worked")
-	}
-}
-
 func TestXORBlake3EncryptDecrypt(t *testing.T) {
 	ciphertext, err := Encrypt(XORBlake3, xorKey, 0, p)
 	if err != nil {
@@ -133,6 +108,10 @@ func TestPseudorandomGeneratorWithBlake3(t *testing.T) {
 	if bytes.Equal(make([]byte, n), p) {
 		t.Fatalf("pseudorandom should not be 0")
 	}
+
+	if len(p) != n {
+		t.Fatalf("PseudorandomGenerator does not extend to n bytes")
+	}
 }
 
 func TestPrgWithSeed(t *testing.T) {
@@ -142,6 +121,10 @@ func TestPrgWithSeed(t *testing.T) {
 	p := PrgWithSeed(seed, n)
 	if bytes.Equal(make([]byte, n), p) {
 		t.Fatalf("pseudorandom should not be 0")
+	}
+
+	if len(p) != n {
+		t.Fatalf("PseudorandomGenerator does not extend to n bytes")
 	}
 }
 
@@ -169,24 +152,6 @@ func BenchmarkPseudorandomCode(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		PseudorandomCode(aesKey, in)
-	}
-}
-
-func BenchmarkXORCipherWithBlake2Encrypt(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		xorCipherWithBlake2(xorKey, 0, p)
-	}
-}
-
-func BenchmarkXORCipherWithBlake2Decrypt(b *testing.B) {
-	c, err := xorCipherWithBlake2(xorKey, 0, p)
-	if err != nil {
-		b.Log(err)
-	}
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
-		xorCipherWithBlake2(xorKey, 0, c)
 	}
 }
 

--- a/internal/crypto/crypto_test.go
+++ b/internal/crypto/crypto_test.go
@@ -135,6 +135,34 @@ func TestPseudorandomGeneratorWithBlake3(t *testing.T) {
 	}
 }
 
+func TestPrgWithSeed(t *testing.T) {
+	seed := make([]byte, 512)
+	prng.Read(seed)
+	n := 1000000
+	p := PrgWithSeed(seed, n)
+	if bytes.Equal(make([]byte, n), p) {
+		t.Fatalf("pseudorandom should not be 0")
+	}
+}
+
+func BenchmarkPrgWithSeed(b *testing.B) {
+	seed := make([]byte, 512)
+	prng.Read(seed)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		PrgWithSeed(seed, 10000000)
+	}
+}
+
+func BenchmarkPseudorandomGeneratorWithBlake3(b *testing.B) {
+	seed := make([]byte, 512)
+	prng.Read(seed)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		PseudorandomGeneratorWithBlake3(blake3.New(), seed, 10000000)
+	}
+}
+
 func BenchmarkPseudorandomCode(b *testing.B) {
 	in := make([]byte, 64)
 	util.SampleBitSlice(prng, in)

--- a/internal/crypto/crypto_test.go
+++ b/internal/crypto/crypto_test.go
@@ -2,8 +2,6 @@ package crypto
 
 import (
 	"bytes"
-	"crypto/aes"
-	"crypto/cipher"
 	"crypto/sha256"
 	"math/rand"
 	"testing"
@@ -37,22 +35,6 @@ func BenchmarkBlake3(b *testing.B) {
 	}
 }
 
-func TestCTREncrypDecrypt(t *testing.T) {
-	ciphertext, err := Encrypt(CTR, aesKey, 0, p)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	plain, err := Decrypt(CTR, aesKey, 0, ciphertext)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if !bytes.Equal(p, plain) {
-		t.Errorf("error in decrypt, want: %s, got: %s", string(p), string(plain))
-	}
-}
-
 func TestGCMEncrypDecrypt(t *testing.T) {
 	ciphertext, err := Encrypt(GCM, aesKey, 0, p)
 	if err != nil {
@@ -66,31 +48,6 @@ func TestGCMEncrypDecrypt(t *testing.T) {
 
 	if !bytes.Equal(p, plain) {
 		t.Errorf("error in decrypt, want: %s, got: %s", string(p), string(plain))
-	}
-}
-
-func TestXORShakeEncryptDecrypt(t *testing.T) {
-	ciphertext, err := Encrypt(XORShake, xorKey, 0, p)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	plain, err := Decrypt(XORShake, xorKey, 1, ciphertext)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if bytes.Equal(p, plain) {
-		t.Fatalf("decryption should not work!")
-	}
-
-	plain, err = Decrypt(XORShake, xorKey, 0, ciphertext)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if !bytes.Equal(p, plain) {
-		t.Fatalf("Decryption should have worked")
 	}
 }
 
@@ -187,24 +144,6 @@ func BenchmarkPseudorandomCode(b *testing.B) {
 	}
 }
 
-func BenchmarkXORCipherWithShakeEncrypt(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		xorCipherWithShake(xorKey, 0, p)
-	}
-}
-
-func BenchmarkXORCipherWithShakeDecrypt(b *testing.B) {
-	c, err := xorCipherWithShake(xorKey, 0, p)
-	if err != nil {
-		b.Log(err)
-	}
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
-		xorCipherWithShake(xorKey, 0, c)
-	}
-}
-
 func BenchmarkXORCipherWithBlake2Encrypt(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		xorCipherWithBlake2(xorKey, 0, p)
@@ -224,6 +163,7 @@ func BenchmarkXORCipherWithBlake2Decrypt(b *testing.B) {
 }
 
 func BenchmarkXORCipherWithBlake3Encrypt(b *testing.B) {
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		xorCipherWithBlake3(xorKey, 0, p)
 	}
@@ -256,24 +196,6 @@ func BenchmarkAesGcmDecrypt(b *testing.B) {
 	}
 }
 
-func BenchmarkAesCtrEncrypt(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		ctrEncrypt(aesKey, p)
-	}
-}
-
-func BenchmarkAesCtrDecrypt(b *testing.B) {
-	c, err := ctrEncrypt(aesKey, p)
-	if err != nil {
-		b.Log(err)
-	}
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
-		ctrDecrypt(aesKey, c)
-	}
-}
-
 func BenchmarkXORCipherWithPRG(b *testing.B) {
 	s := blake3.New()
 	b.ResetTimer()
@@ -282,49 +204,10 @@ func BenchmarkXORCipherWithPRG(b *testing.B) {
 	}
 }
 
-func BenchmarkXORCipherWithAESCTR(b *testing.B) {
-	block, err := aes.NewCipher(aesKey)
-	if err != nil {
-		b.Log(err)
-	}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		xorCipherWithAESCTR(block, xorKey, p)
-	}
-}
-
-func BenchmarkXORCipherWithAESCTR2(b *testing.B) {
-	block, err := aes.NewCipher(aesKey)
-	if err != nil {
-		b.Log(err)
-	}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		xorCipherWithAESCTR2(block, xorKey, p)
-	}
-}
-
 func BenchmarkPRGWithBlake3(b *testing.B) {
 	s := blake3.New()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		PseudorandomGeneratorWithBlake3(s, xorKey, len(p))
-	}
-}
-
-func BenchmarkPRGWithAESGCM(b *testing.B) {
-	block, err := aes.NewCipher(aesKey)
-	if err != nil {
-		b.Log(err)
-	}
-
-	aesgcm, err := cipher.NewGCM(block)
-	if err != nil {
-		b.Log(err)
-	}
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
-		pseudorandomGeneratorWithAESGCM(aesgcm, xorKey, len(p))
 	}
 }

--- a/internal/cuckoo/cuckoo.go
+++ b/internal/cuckoo/cuckoo.go
@@ -237,7 +237,7 @@ func (c *Cuckoo) LoadFactor() (factor float64) {
 // Len returns the total size of the cuckoo struct
 // which is equal to bucketSize + stashSize
 func (c *Cuckoo) Len() uint64 {
-	return c.bucketSize //+ uint64(c.StashSize())
+	return c.bucketSize
 }
 
 func (v *value) oprfInput() []byte {

--- a/internal/cuckoo/cuckoo.go
+++ b/internal/cuckoo/cuckoo.go
@@ -246,8 +246,7 @@ func (v *value) oprfInput() []byte {
 		return []byte{255}
 	}
 
-	v.item[len(v.item)-1] = v.item[len(v.item)-1] ^ v.hIdx
-	return v.item
+	return append(v.item, v.hIdx)
 }
 
 // OPRFInput returns the OPRF input for KKRT Receiver
@@ -260,22 +259,6 @@ func (c *Cuckoo) OPRFInput() [][]byte {
 		inputs[i] = b.oprfInput()
 	}
 	return inputs
-}
-
-func (v *value) GetItem() []byte {
-	return v.item
-}
-
-func (v *value) GetHashIdx() uint8 {
-	return v.hIdx
-}
-
-func (c *Cuckoo) Bucket() []value {
-	return c.buckets
-}
-
-func (c *Cuckoo) BucketSize() int {
-	return int(c.bucketSize)
 }
 
 func max(a, b uint64) uint64 {

--- a/internal/oprf/oprf_test.go
+++ b/internal/oprf/oprf_test.go
@@ -66,7 +66,7 @@ func TestKKRT(t *testing.T) {
 
 	// start timer
 	start := time.Now()
-	receiverOPRF, err := NewKKRT(baseCount, k, ot.Simplest, false)
+	receiverOPRF, err := NewKKRT(baseCount, k, ot.NaorPinkas, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -76,7 +76,7 @@ func TestKKRT(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	senderOPRF, err := NewKKRT(baseCount, k, ot.Simplest, false)
+	senderOPRF, err := NewKKRT(baseCount, k, ot.NaorPinkas, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -151,7 +151,7 @@ func TestImprovedKKRT(t *testing.T) {
 
 	// start timer
 	start := time.Now()
-	receiverOPRF, err := NewImprovedKKRT(baseCount, k, ot.Simplest, false)
+	receiverOPRF, err := NewImprovedKKRT(baseCount, k, ot.NaorPinkas, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -161,7 +161,7 @@ func TestImprovedKKRT(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	senderOPRF, err := NewImprovedKKRT(baseCount, k, ot.Simplest, false)
+	senderOPRF, err := NewImprovedKKRT(baseCount, k, ot.NaorPinkas, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/oprf/oprf_test.go
+++ b/internal/oprf/oprf_test.go
@@ -15,7 +15,7 @@ import (
 var (
 	network   = "tcp"
 	address   = "127.0.0.1:"
-	baseCount = 100000
+	baseCount = 1000
 	prng      = rand.New(rand.NewSource(time.Now().UnixNano()))
 	choices   = genChoiceString()
 	k         = 512
@@ -24,7 +24,7 @@ var (
 func genChoiceString() [][]byte {
 	choices := make([][]byte, baseCount)
 	for i := range choices {
-		choices[i] = make([]byte, 64)
+		choices[i] = make([]byte, 65)
 		prng.Read(choices[i])
 	}
 	return choices

--- a/internal/oprf/oprf_test.go
+++ b/internal/oprf/oprf_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/optable/match/internal/ot"
+	"github.com/optable/match/internal/util"
 )
 
 var (
@@ -17,6 +18,7 @@ var (
 	baseCount = 100000
 	prng      = rand.New(rand.NewSource(time.Now().UnixNano()))
 	choices   = genChoiceString()
+	k         = 512
 )
 
 func genChoiceString() [][]byte {
@@ -64,7 +66,7 @@ func TestKKRT(t *testing.T) {
 
 	// start timer
 	start := time.Now()
-	receiverOPRF, err := NewKKRT(baseCount, 424, ot.Simplest, false)
+	receiverOPRF, err := NewKKRT(baseCount, k, ot.Simplest, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -74,7 +76,7 @@ func TestKKRT(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	senderOPRF, err := NewKKRT(baseCount, 424, ot.Simplest, false)
+	senderOPRF, err := NewKKRT(baseCount, k, ot.Simplest, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -130,7 +132,7 @@ func TestKKRT(t *testing.T) {
 
 	for i, o := range out {
 		// encode choice with key
-		enc, err := senderOPRF.Encode(keys[i], choices[i])
+		enc, err := keys[i].Encode(choices[i])
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -149,7 +151,7 @@ func TestImprovedKKRT(t *testing.T) {
 
 	// start timer
 	start := time.Now()
-	receiverOPRF, err := NewImprovedKKRT(baseCount, 424, ot.Simplest, false)
+	receiverOPRF, err := NewImprovedKKRT(baseCount, k, ot.Simplest, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -159,7 +161,7 @@ func TestImprovedKKRT(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	senderOPRF, err := NewImprovedKKRT(baseCount, 424, ot.Simplest, false)
+	senderOPRF, err := NewImprovedKKRT(baseCount, k, ot.Simplest, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -215,7 +217,7 @@ func TestImprovedKKRT(t *testing.T) {
 
 	for i, o := range out {
 		// encode choice with key
-		enc, err := senderOPRF.Encode(keys[i], choices[i])
+		enc, err := keys[i].Encode(choices[i])
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -224,5 +226,20 @@ func TestImprovedKKRT(t *testing.T) {
 			t.Logf("choice[%d]=%v\n", i, choices[i])
 			t.Fatalf("Improved KKRT OPRF failed, got: %v, want %v", enc, o)
 		}
+	}
+}
+
+func BenchmarkEncode(b *testing.B) {
+	sk := make([]byte, 16)
+	s := make([]byte, 64)
+	q := make([]byte, 64)
+	util.SampleBitSlice(prng, sk)
+	util.SampleBitSlice(prng, s)
+	util.SampleBitSlice(prng, q)
+	key := Key{sk: sk, s: s, q: q}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		key.Encode(q)
 	}
 }

--- a/internal/ot/baseOt_test.go
+++ b/internal/ot/baseOt_test.go
@@ -17,7 +17,7 @@ var (
 	address    = "127.0.0.1:"
 	curve      = "P256"
 	cipherMode = crypto.XORBlake3
-	baseCount  = 1024
+	baseCount  = 512
 	messages   = genMsg(baseCount, 2)
 	msgLen     = make([]int, len(messages))
 	choices    = genChoiceBits(baseCount)
@@ -29,7 +29,7 @@ func genMsg(n, t int) [][][]byte {
 	for i := 0; i < n; i++ {
 		data[i] = make([][]byte, t)
 		for j := range data[i] {
-			data[i][j] = make([]byte, 64)
+			data[i][j] = make([]byte, 1000)
 			r.Read(data[i][j])
 		}
 	}

--- a/internal/ot/baseOt_test.go
+++ b/internal/ot/baseOt_test.go
@@ -29,7 +29,7 @@ func genMsg(n, t int) [][][]byte {
 	for i := 0; i < n; i++ {
 		data[i] = make([][]byte, t)
 		for j := range data[i] {
-			data[i][j] = make([]byte, 1000)
+			data[i][j] = make([]byte, 512)
 			r.Read(data[i][j])
 		}
 	}

--- a/internal/ot/improved_iknp_nco.go
+++ b/internal/ot/improved_iknp_nco.go
@@ -5,7 +5,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"math/rand"
 	mrand "math/rand"
 
 	"github.com/optable/match/internal/crypto"
@@ -31,7 +30,7 @@ type imprvIKNPNCO struct {
 	k      int
 	n      int
 	msgLen []int
-	prng   *rand.Rand
+	prng   *mrand.Rand
 	g      *blake3.Hasher
 }
 

--- a/internal/ot/nChooseOne_test.go
+++ b/internal/ot/nChooseOne_test.go
@@ -8,6 +8,8 @@ import (
 	"time"
 )
 
+var k = 512
+
 func initKKRTReceiver(ot OT, choices []uint8, msgBus chan<- []byte, errs chan<- error) (string, error) {
 	l, err := net.Listen(network, address)
 	if err != nil {
@@ -59,7 +61,7 @@ func TestKKRT(t *testing.T) {
 
 	// start timer
 	start := time.Now()
-	ot, err := NewKKRT(baseCount, 128, tuple, Simplest, false, msgLen)
+	ot, err := NewKKRT(baseCount, k, tuple, Simplest, false, msgLen)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -78,7 +80,7 @@ func TestKKRT(t *testing.T) {
 			errs <- fmt.Errorf("Error creating IKNP OT: %s", err)
 		}
 
-		ot, err := NewKKRT(baseCount, 128, tuple, Simplest, false, msgLen)
+		ot, err := NewKKRT(baseCount, k, tuple, Simplest, false, msgLen)
 		if err != nil {
 			errs <- err
 		}
@@ -141,7 +143,7 @@ func TestImprovedIKNPNCO(t *testing.T) {
 
 	// start timer
 	start := time.Now()
-	ot, err := NewImprovedIKNPNCO(baseCount, 128, tuple, Simplest, false, msgLen)
+	ot, err := NewImprovedIKNPNCO(baseCount, k, tuple, Simplest, false, msgLen)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -160,7 +162,7 @@ func TestImprovedIKNPNCO(t *testing.T) {
 			errs <- fmt.Errorf("Error creating improved IKNP NchooseOne OT extension: %s", err)
 		}
 
-		ot, err := NewImprovedIKNPNCO(baseCount, 128, tuple, Simplest, false, msgLen)
+		ot, err := NewImprovedIKNPNCO(baseCount, k, tuple, Simplest, false, msgLen)
 		if err != nil {
 			errs <- err
 		}
@@ -223,7 +225,7 @@ func TestImprovedKKRT(t *testing.T) {
 
 	// start timer
 	start := time.Now()
-	ot, err := NewImprovedKKRT(baseCount, 128, tuple, Simplest, false, msgLen)
+	ot, err := NewImprovedKKRT(baseCount, k, tuple, Simplest, false, msgLen)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -242,7 +244,7 @@ func TestImprovedKKRT(t *testing.T) {
 			errs <- fmt.Errorf("Error creating improved KKRT OT extension: %s", err)
 		}
 
-		ot, err := NewImprovedKKRT(baseCount, 128, tuple, Simplest, false, msgLen)
+		ot, err := NewImprovedKKRT(baseCount, k, tuple, Simplest, false, msgLen)
 		if err != nil {
 			errs <- err
 		}

--- a/internal/ot/points.go
+++ b/internal/ot/points.go
@@ -34,9 +34,8 @@ func (p points) scalarMult(scalar []byte) points {
 
 func (p points) sub(q points) points {
 	// p - q = p.x + q.x, p.y - q.y
-	n := big.NewInt(0)
-	n.Neg(q.y)
-	x, y := p.curve.Add(p.x, p.y, q.x, n)
+	x := big.NewInt(0)
+	x, y := p.curve.Add(p.x, p.y, q.x, x.Neg(q.y))
 	return newPoints(p.curve, x, y)
 }
 
@@ -46,8 +45,7 @@ func (p points) isOnCurve() bool {
 
 // deriveKey returns a key of 32 byte from an elliptic curve point
 func (p points) deriveKey() []byte {
-	buf := elliptic.Marshal(p.curve, p.x, p.y)
-	key := blake3.Sum256(buf)
+	key := blake3.Sum256(p.x.Bytes())
 	return key[:]
 }
 

--- a/internal/ot/points_test.go
+++ b/internal/ot/points_test.go
@@ -83,7 +83,7 @@ func TestDeriveKeyPoints(t *testing.T) {
 	p := newPoints(c, bx, by)
 	key := p.deriveKey()
 
-	key2 := blake3.Sum256(elliptic.Marshal(c, bx, by))
+	key2 := blake3.Sum256(bx.Bytes())
 	if string(key) != string(key2[:]) || len(key) != 32 {
 		t.Fatal("Error in points deriveKey")
 	}
@@ -99,5 +99,29 @@ func TestGenerateKeyWithPoints(t *testing.T) {
 	d := p.scalarMult(s)
 	if !arePointsEqual(d, P) {
 		t.Fatal("Error in points generateKeyWithPoints")
+	}
+}
+
+func BenchmarkDeriveKey(b *testing.B) {
+	c, _ = initCurve(curve)
+	x := big.NewInt(1)
+	y := big.NewInt(2)
+	p := newPoints(c, x, y)
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		p.deriveKey()
+	}
+}
+
+func BenchmarkSub(b *testing.B) {
+	c, _ = initCurve(curve)
+	x := big.NewInt(1)
+	y := big.NewInt(2)
+	p := newPoints(c, x, y)
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		p.sub(p)
 	}
 }

--- a/internal/util/bits.go
+++ b/internal/util/bits.go
@@ -3,6 +3,7 @@ package util
 import (
 	"fmt"
 	"io"
+	"sync"
 )
 
 var ErrByteLengthMissMatch = fmt.Errorf("provided bytes do not have the same length for XOR operations")
@@ -169,4 +170,85 @@ func ExtractBytesToBits(src, dst []byte) {
 	for i = 0; i < len(dst)%8; i++ {
 		dst[(len(src)-1)*8+i] = uint8((src[len(src)-1] >> i) & 0x01)
 	}
+}
+
+// The major failing of my last attempt at concurrent transposition
+// was that each goroutine (and there were far too many) was accessing
+// the same shared array. This meant that the cache on each core had to
+// be constantly updated as each coroutine updated their cache-local
+// version. Instead this version splits everything by column. Each
+// goroutine reads from the same shared matrix, but since nothing is
+// is changed, the local cache shouldn't need an update. Then each
+// goroutine sends the transposed row back to a channel in an ordered set.
+// Once all transpositions are done, rows are recombined into a 2D matrix.
+func ConcurrentColumnarTranspose(matrix [][]uint8) [][]uint8 {
+	var wg sync.WaitGroup
+	m := len(matrix)
+	n := len(matrix[0])
+	tr := make([][]uint8, n)
+
+	// the optimal number of goroutines will likely vary due to
+	// hardware and array size
+	//nThreads := n // one thread per column (likely only efficient for huge matrix)
+	// nThreads := runtime.NumCPU()
+	// nThreads := runtime.NumCPU()*2
+	nThreads := 12
+	// add to quick check to ensure there are not more threads than columns
+	if n < nThreads {
+		nThreads = n
+	}
+
+	// number of columns for which each goroutine is responsible
+	nColumns := n / nThreads
+
+	// create ordered channels to store values from goroutines
+	// each channel is buffered to store the number of desired rows
+	channels := make([]chan []uint8, nThreads)
+	for i := 0; i < nThreads-1; i++ {
+		channels[i] = make(chan []uint8, nColumns)
+	}
+	// last one may have excess columns
+	channels[nThreads-1] = make(chan []uint8, nColumns+n%nThreads)
+
+	// goroutine
+	//wg.Add(nThreads)
+	for i := 0; i < nThreads; i++ {
+		wg.Add(1)
+		go func(i int) {
+			//	fmt.Println("goroutine", i, "created")
+			defer wg.Done()
+			// we need to handle excess columns which don't evenly divide among
+			// number of threads -> in this case, I just add to the last goroutine
+			// perhaps a more sophisticated division of labor would be more efficient
+			var extraColumns int
+			if i == nThreads-1 {
+				extraColumns = n % nThreads
+			}
+
+			for c := 0; c < (nColumns + extraColumns); c++ {
+				row := make([]uint8, m)
+				for r := 0; r < m; r++ {
+					row[r] = matrix[r][(i*nColumns)+c]
+				}
+
+				channels[i] <- row
+			}
+
+			close(channels[i])
+		}(i)
+	}
+
+	// Wait until all goroutines have finished
+	wg.Wait()
+
+	// Reconstruct a transposed matrix from the channels
+	for i, channel := range channels {
+		var j int
+		for row := range channel {
+			tr[(i*nColumns)+j] = row
+			j++
+		}
+	}
+
+	return tr
 }

--- a/pkg/kkrtpsi/kkrtpsi.go
+++ b/pkg/kkrtpsi/kkrtpsi.go
@@ -67,7 +67,8 @@ func makeJob(hasher hash.Hasher, batchSize int, f func(hashEncodingJob)) hashEnc
 func (id hashable) encodeAndHash(oprfKeys []oprf.Key, hasher hash.Hasher) (hashes [cuckoo.Nhash]uint64) {
 	var encoded = make([]byte, k)
 	for hIdx, bucketIdx := range id.bucketIdx {
-		encoded, _ = oprfKeys[bucketIdx].Encode(append(id.identifier, uint8(hIdx)))
+		id.identifier[len(id.identifier)-1] = id.identifier[len(id.identifier)-1] ^ uint8(hIdx)
+		encoded, _ = oprfKeys[bucketIdx].Encode(id.identifier)
 		hashes[hIdx] = hasher.Hash64(encoded)
 	}
 

--- a/pkg/kkrtpsi/kkrtpsi.go
+++ b/pkg/kkrtpsi/kkrtpsi.go
@@ -1,8 +1,14 @@
 package kkrtpsi
 
 import (
+	"encoding/binary"
+	"io"
+
+	"github.com/optable/match/internal/cuckoo"
 	"github.com/optable/match/internal/hash"
 )
+
+const K = 512
 
 // findK returns the number of base OT for OPRF
 // these numbers are from the paper: Efficient Batched Oblivious PRF with Applications to Private Set Intersection
@@ -40,4 +46,15 @@ func HashAll(h hash.Hasher, input <-chan []byte) <-chan uint64 {
 		}
 	}()
 	return hashes
+}
+
+// HashRead reads one hash
+func EncodesRead(r io.Reader, u *[cuckoo.Nhash]uint64) (err error) {
+	err = binary.Read(r, binary.BigEndian, u)
+	return
+}
+
+// HashWrite writes one hash out
+func EncodesWrite(w io.Writer, u [cuckoo.Nhash]uint64) error {
+	return binary.Write(w, binary.BigEndian, u)
 }

--- a/pkg/kkrtpsi/kkrtpsi.go
+++ b/pkg/kkrtpsi/kkrtpsi.go
@@ -3,12 +3,18 @@ package kkrtpsi
 import (
 	"encoding/binary"
 	"io"
+	"runtime"
+	"sync"
 
 	"github.com/optable/match/internal/cuckoo"
 	"github.com/optable/match/internal/hash"
+	"github.com/optable/match/internal/oprf"
 )
 
-const K = 512
+const (
+	K         = 512
+	batchSize = 512
+)
 
 // findK returns the number of base OT for OPRF
 // these numbers are from the paper: Efficient Batched Oblivious PRF with Applications to Private Set Intersection
@@ -33,21 +39,6 @@ func findK(n int64) int {
 	}
 }
 
-// HashAll reads all inputs from inputs
-// and hashes them until inputs closes
-func HashAll(h hash.Hasher, input <-chan []byte) <-chan uint64 {
-	var hashes = make(chan uint64)
-
-	// just read and hash
-	go func() {
-		defer close(hashes)
-		for in := range input {
-			hashes <- h.Hash64(in)
-		}
-	}()
-	return hashes
-}
-
 // HashRead reads one hash
 func EncodesRead(r io.Reader, u *[cuckoo.Nhash]uint64) (err error) {
 	err = binary.Read(r, binary.BigEndian, u)
@@ -57,4 +48,93 @@ func EncodesRead(r io.Reader, u *[cuckoo.Nhash]uint64) (err error) {
 // HashWrite writes one hash out
 func EncodesWrite(w io.Writer, u [cuckoo.Nhash]uint64) error {
 	return binary.Write(w, binary.BigEndian, u)
+}
+
+type hashEncodingJob struct {
+	batchSize   int
+	identifiers []hashable
+	hashed      [][cuckoo.Nhash]uint64
+	execute     func(job hashEncodingJob)
+}
+
+func makeJob(hasher hash.Hasher, batchSize int, f func(hashEncodingJob)) hashEncodingJob {
+	return hashEncodingJob{
+		batchSize:   batchSize,
+		identifiers: make([]hashable, batchSize),
+		execute:     f}
+}
+
+func (id hashable) encodeAndHash(oprfSender oprf.OPRF, oprfKeys []oprf.Key, hasher hash.Hasher) (hashes [cuckoo.Nhash]uint64) {
+	for hIdx, bucketIdx := range id.bucketIdx {
+		encoded, _ := oprfSender.Encode(oprfKeys[bucketIdx], append(id.identifier, uint8(hIdx)))
+		hashes[hIdx] = hasher.Hash64(encoded)
+	}
+
+	return
+}
+
+// HashAllParallel reads all identifiers from identifiers
+// and parallel hashes them until identifiers closes
+func EncodeAndHashAllParallel(oprfSender oprf.OPRF, oprfKeys []oprf.Key, hasher hash.Hasher, identifiers <-chan hashable) <-chan [cuckoo.Nhash]uint64 {
+	// one wg.Add() per batch + one for the batcher go routine
+	var jobPool = make(chan hashEncodingJob)
+	var wg sync.WaitGroup
+
+	// work on the jobPool
+	for i := 0; i < runtime.GOMAXPROCS(0); i++ {
+		go func() {
+			for job := range jobPool {
+				var hashed = make([][cuckoo.Nhash]uint64, job.batchSize)
+				for i := 0; i < job.batchSize; i++ {
+					hashed[i] = job.identifiers[i].encodeAndHash(oprfSender, oprfKeys, hasher)
+				}
+				job.hashed = hashed
+				job.execute(job)
+			}
+		}()
+	}
+
+	var encoded = make(chan [cuckoo.Nhash]uint64)
+	execute := func(job hashEncodingJob) {
+		// pump everything out
+		for i := 0; i < job.batchSize; i++ {
+			encoded <- job.hashed[i]
+		}
+		wg.Done()
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		var i = 0
+		// init a first batch
+		var batch = makeJob(hasher, batchSize, execute)
+		for identifier := range identifiers {
+			// accumulate a batch
+			batch.identifiers[i] = identifier
+			i++
+			// send it out?
+			if i == batchSize {
+				wg.Add(1)
+				jobPool <- batch
+				// reset batch
+				batch = makeJob(hasher, batchSize, execute)
+				i = 0
+			}
+		}
+		// anything left here?
+		if i != 0 {
+			batch.batchSize = i
+			wg.Add(1)
+			jobPool <- batch
+		}
+	}()
+
+	// turn the lights off on your way out
+	go func() {
+		wg.Wait()
+		close(encoded)
+	}()
+
+	return encoded
 }

--- a/pkg/kkrtpsi/kkrtpsi.go
+++ b/pkg/kkrtpsi/kkrtpsi.go
@@ -67,8 +67,7 @@ func makeJob(hasher hash.Hasher, batchSize int, f func(hashEncodingJob)) hashEnc
 func (id hashable) encodeAndHash(oprfKeys []oprf.Key, hasher hash.Hasher) (hashes [cuckoo.Nhash]uint64) {
 	var encoded = make([]byte, k)
 	for hIdx, bucketIdx := range id.bucketIdx {
-		id.identifier[len(id.identifier)-1] = id.identifier[len(id.identifier)-1] ^ uint8(hIdx)
-		encoded, _ = oprfKeys[bucketIdx].Encode(id.identifier)
+		encoded, _ = oprfKeys[bucketIdx].Encode(append(id.identifier, uint8(hIdx)))
 		hashes[hIdx] = hasher.Hash64(encoded)
 	}
 

--- a/pkg/kkrtpsi/receiver.go
+++ b/pkg/kkrtpsi/receiver.go
@@ -76,7 +76,7 @@ func (r *Receiver) Intersect(ctx context.Context, n int64, identifiers <-chan []
 
 	// stage 2: prepare OPRF receive input and run Receive to get OPRF output
 	stage2 := func() error {
-		oprfInputSize := int64(cuckooHashTable.Len())
+		oprfInputSize := int64(len(oprfInputs))
 
 		// inform the sender of the size
 		// its about to receive
@@ -118,12 +118,11 @@ func (r *Receiver) Intersect(ctx context.Context, n int64, identifiers <-chan []
 		}
 		// hash local oprf output
 		hasher, _ := hash.New(hash.Highway, seeds[0])
-		for i, value := range cuckooHashTable.Bucket() {
-			if !value.Empty() {
+		for i, input := range oprfInputs {
+			// check if it was a dummy input
+			if len(input) != 1 && input[0] != 255 {
 				// insert into proper map
-				id := value.GetItem()
-				id[len(id)-1] = id[len(id)-1] ^ value.GetHashIdx()
-				localEncodings[value.GetHashIdx()][hasher.Hash64(oprfOutput[i])] = id
+				localEncodings[input[len(input)-1]][hasher.Hash64(oprfOutput[i])] = input[:len(input)-1]
 			}
 		}
 

--- a/pkg/kkrtpsi/receiver.go
+++ b/pkg/kkrtpsi/receiver.go
@@ -93,7 +93,7 @@ func (r *Receiver) Intersect(ctx context.Context, n int64, identifiers <-chan []
 			return err
 		}
 
-		oReceiver, err := oprf.NewKKRT(int(oprfInputSize), k, ot.Simplest, false)
+		oReceiver, err := oprf.NewKKRT(int(oprfInputSize), k, ot.NaorPinkas, false)
 		if err != nil {
 			return err
 		}

--- a/pkg/kkrtpsi/receiver.go
+++ b/pkg/kkrtpsi/receiver.go
@@ -41,7 +41,6 @@ func (r *Receiver) Intersect(ctx context.Context, n int64, identifiers <-chan []
 	var seeds [cuckoo.Nhash][]byte
 	var intersection [][]byte
 	var oprfOutput [][]byte
-	var oprfOutputSize int
 	var cuckooHashTable *cuckoo.Cuckoo
 	var input = make(chan [][]byte, 1)
 	//var errBus = make(chan error)
@@ -87,7 +86,6 @@ func (r *Receiver) Intersect(ctx context.Context, n int64, identifiers <-chan []
 	// stage 2: prepare OPRF receive input and run Receive to get OPRF output
 	stage2 := func() error {
 		oprfInputSize := int64(cuckooHashTable.Len())
-		oprfOutputSize = findK(oprfInputSize)
 
 		// inform the sender of the size
 		// its about to receive
@@ -95,7 +93,7 @@ func (r *Receiver) Intersect(ctx context.Context, n int64, identifiers <-chan []
 			return err
 		}
 
-		oReceiver, err := oprf.NewKKRT(int(oprfInputSize), oprfOutputSize, ot.Simplest, false)
+		oReceiver, err := oprf.NewKKRT(int(oprfInputSize), k, ot.Simplest, false)
 		if err != nil {
 			return err
 		}

--- a/pkg/kkrtpsi/sender.go
+++ b/pkg/kkrtpsi/sender.go
@@ -93,7 +93,7 @@ func (s *Sender) Send(ctx context.Context, n int64, identifiers <-chan []byte) (
 		}
 
 		// instantiate OPRF sender with agreed parameters
-		oSender, err := oprf.NewKKRT(int(oprfInputSize), k, ot.Simplest, false)
+		oSender, err := oprf.NewKKRT(int(oprfInputSize), k, ot.NaorPinkas, false)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
main changes:
* Cleanup on unused code in internal/crypto (test and benchmarked, but settled on the best ones)
* add batch concurrency machinery for sender to encode and hash a batch of IDs
* sender sends the hashed encoded IDs right away, the receiver reads them and check if it's present in his local hashed encoded ID map to intersect