### PR TITLE
use logger in kkrt

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Similar to the dhpsi protocol, the KKRT PSI, also known as the Batched-OPRF PSI,
 
 ## logging
 
-[logr](https://github.com/go-logr/logr) is used internally for logging, which accepts a `logr.Logger` object. See the [documentation](https://github.com/go-logr/logr#implementations-non-exhaustive) on `logr` for various concrete implementation of logging api. Example implementation of match sender and receiver uses [stdr](https://github.com/go-logr/stdr) which logs to `os.Stderr`.
+[logr](https://github.com/go-logr/logr) is used internally for logging, which accepts a `logr.Logger` object. See the [documentation](https://github.com/go-logr/logr#implementations-non-exhaustive) on `logr` for various concrete implementations of logging api. Example implementation of match sender and receiver uses [stdr](https://github.com/go-logr/stdr) which logs to `os.Stderr`.
 
 ### pass logger to sender or receiver
 To pass a logger to a sender or a receiver, create a new context with the parent context and `logr.Logger` object as follows

--- a/README.md
+++ b/README.md
@@ -27,6 +27,53 @@ The [bloomfilter](https://en.wikipedia.org/wiki/Bloom_filter) based PSI: an *ins
 
 Similar to the dhpsi protocol, the KKRT PSI, also known as the Batched-OPRF PSI, is a semi-honest secure private set intersection protocol that has significantly less computation cost, but requires more network communication. An extensive description of the protocol is available [here](pkg/kkrtpsi/README.md).
 
+## logging
+
+[logr](https://github.com/go-logr/logr) is used internally for logging, which accepts a `logr.Logger` object. See the [documentation](https://github.com/go-logr/logr#implementations-non-exhaustive) on `logr` for various concrete implementation of logging api. Example implementation of match sender and receiver uses [stdr](https://github.com/go-logr/stdr) which logs to `os.Stderr`.
+
+### pass logger to sender or receiver
+To pass a logger to a sender or a receiver, create a new context with the parent context and `logr.Logger` object as follows
+```golang
+// create sender and logger
+...
+// pass logger to context
+ctx := logr.NewContext(parentCtx, logger)
+err := sender.Send(ctx, n, identifiers)
+if err != nil {
+    logger.Error(err, "sender failed to send")
+}
+```
+Similarly for receiver,
+```golang
+// create receiver and logger
+...
+// pass logger to context
+ctx := logr.NewContext(parentCtx, logger)
+intersection, err := receiver.Intersect(ctx, n, identifiers)
+if err != nil {
+    logger.Error(err, "receiver intersection failed")
+}
+```
+
+### verbosity
+Each PSI implementation logs the stage progression, set `logr.Logger` verbosity to `1` to see the logs.
+example for `github.com/go-logr/stdr`:
+```golang
+logger := stdr.New(nil)
+stdr.SetVerbosity(1)
+```
+running the example implementation for `dhpsi` we see the following logs:
+```bash
+$go run examples/sender/main.go -proto dhpsi -v 1
+...
+2021/11/11 11:16:12 "level"=1 "msg"="Starting stage 1" "protocol"="dhpsi"
+2021/11/11 11:16:12 "level"=1 "msg"="Finished stage 1" "protocol"="dhpsi"
+2021/11/11 11:16:12 "level"=1 "msg"="Starting stage 2" "protocol"="dhpsi"
+2021/11/11 11:16:12 "level"=1 "msg"="Finished stage 2" "protocol"="dhpsi"
+2021/11/11 11:16:12 "level"=1 "msg"="sender finished" "protocol"="dhpsi"
+...
+```
+
 # testing
 
 A complete test suite for all PSIs is present [here](test/psi). Don't hesitate to take a look and help us improve the quality of the testing by reporting problems and observations! The PSIs have only been tested on AMD64.

--- a/examples/receiver/main.go
+++ b/examples/receiver/main.go
@@ -137,7 +137,6 @@ func main() {
 				v.SetNoDelay(false)
 			}
 			// make the receiver
-
 			receiver, _ := psi.NewReceiver(psiType, c)
 			// and hand it off
 			wg.Add(1)

--- a/examples/receiver/main.go
+++ b/examples/receiver/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"io"
 	"log"
+	"math"
 	"net"
 	"os"
 	"runtime"
@@ -37,7 +38,7 @@ func showUsageAndExit(exitcode int) {
 func memUsageToStdErr(logger logr.Logger) {
 	var m runtime.MemStats
 	runtime.ReadMemStats(&m) // https://cs.opensource.google/go/go/+/go1.17.1:src/runtime/mstats.go;l=107
-	logger.V(1).Info("Final stats", "Total memory", m.Sys)
+	logger.V(1).Info("Final stats", "Total memory (GiB)", math.Round(float64(m.Sys)*100/(1024*1024*1024))/100)
 	logger.V(1).Info("Final stats", "Garbage collector calls:", m.NumGC)
 }
 

--- a/examples/receiver/main.go
+++ b/examples/receiver/main.go
@@ -11,6 +11,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/go-logr/logr"
+	"github.com/go-logr/stdr"
 	"github.com/optable/match/internal/util"
 	"github.com/optable/match/pkg/psi"
 )
@@ -39,6 +41,30 @@ func memUsageToStdErr() {
 	log.Printf("Garbage collector calls: %v\n", m.NumGC)
 }
 
+func exitOnErr(logger logr.Logger, err error, msg string) {
+	if err != nil {
+		logger.Error(err, msg)
+		os.Exit(1)
+	}
+}
+
+// getLogger returns a stdr.Logger that implements the logr.Logger interface
+// and sets the verbosity of the returned logger.
+// set v to 0 for info level messages,
+// 1 for debug messages and 2 for trace level message.
+// any other verbosity level will default to 0.
+func getLogger(v int) logr.Logger {
+	logger := stdr.New(nil)
+	// bound check
+	if v > 2 || v < 0 {
+		v = 0
+		logger.Info("Invalid verbosity, setting logger to display info level messages only.")
+	}
+	stdr.SetVerbosity(v)
+
+	return logger
+}
+
 var out *string
 
 func main() {
@@ -48,7 +74,7 @@ func main() {
 	var file = flag.String("in", defaultSenderFileName, "A list of IDs terminated with a newline")
 	out = flag.String("out", defaultCommonFileName, "A list of IDs that intersect between the receiver and the sender")
 	var once = flag.Bool("once", false, "Exit after processing one receiver")
-
+	var verbose = flag.Int("v", 0, "Verbosity level, default to -v 0 for info level messages, -v 1 for debug messages, and -v 2 for trace level message.")
 	var showHelp = flag.Bool("h", false, "Show help message")
 
 	log.SetFlags(0)
@@ -76,39 +102,33 @@ func main() {
 	}
 
 	log.Printf("operating with protocol %s", *protocol)
+	// fetch stdr logger
+	mlog := getLogger(*verbose)
 
 	// open file
 	f, err := os.Open(*file)
-	if err != nil {
-		log.Fatal(err)
-	}
+	exitOnErr(mlog, err, "failed to open file")
 	defer f.Close()
 
 	// count lines
 	log.Printf("counting lines in %s", *file)
 	t := time.Now()
 	n, err := util.Count(f)
-	if err != nil {
-		log.Fatal(err)
-	}
+	exitOnErr(mlog, err, "failed to count")
 	log.Printf("that took %v", time.Since(t))
 	log.Printf("operating on %s with %d IDs", *file, n)
 
 	// get a listener
 	l, err := net.Listen("tcp", *port)
-	if err != nil {
-		log.Fatal(err)
-	}
+	exitOnErr(mlog, err, "failed to listen on tcp port")
 	log.Printf("receiver listening on %s", *port)
 	for {
 		if c, err := l.Accept(); err != nil {
-			log.Fatal(err)
+			exitOnErr(mlog, err, "failed to accept incoming connection")
 		} else {
 			log.Printf("handling sender %s", c.RemoteAddr())
 			f, err := os.Open(*file)
-			if err != nil {
-				log.Fatal(err)
-			}
+			exitOnErr(mlog, err, "failed to open file")
 			// enable nagle
 			switch v := c.(type) {
 			// enable nagle
@@ -116,13 +136,14 @@ func main() {
 				v.SetNoDelay(false)
 			}
 			// make the receiver
+
 			receiver, _ := psi.NewReceiver(psiType, c)
 			// and hand it off
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
 				defer c.Close()
-				handle(receiver, n, f)
+				handle(receiver, n, f, logr.NewContext(context.Background(), mlog))
 				log.Printf("handled sender %s", c.RemoteAddr())
 			}()
 
@@ -134,10 +155,11 @@ func main() {
 	}
 }
 
-func handle(r psi.Receiver, n int64, f io.ReadCloser) {
+func handle(r psi.Receiver, n int64, f io.ReadCloser, ctx context.Context) {
 	defer f.Close()
 	ids := util.Exhaust(n, f)
-	if i, err := r.Intersect(context.Background(), n, ids); err != nil {
+	logger, _ := logr.FromContext(ctx)
+	if i, err := r.Intersect(ctx, n, ids); err != nil {
 		log.Printf("intersect failed (%d): %v", len(i), err)
 	} else {
 		// write memory usage to stderr
@@ -149,11 +171,11 @@ func handle(r psi.Receiver, n int64, f io.ReadCloser) {
 			for _, id := range i {
 				// and write it
 				if _, err := f.Write(append(id, "\n"...)); err != nil {
-					log.Fatal(err)
+					exitOnErr(logger, err, "failed to write intersected ID to file")
 				}
 			}
 		} else {
-			log.Fatal(err)
+			exitOnErr(logger, err, "failed to perform PSI")
 		}
 	}
 }

--- a/examples/receiver/main.go
+++ b/examples/receiver/main.go
@@ -159,7 +159,7 @@ func main() {
 func handle(r psi.Receiver, n int64, f io.ReadCloser, ctx context.Context) {
 	defer f.Close()
 	ids := util.Exhaust(n, f)
-	logger, _ := logr.FromContext(ctx)
+	logger := logr.FromContextOrDiscard(ctx)
 	if i, err := r.Intersect(ctx, n, ids); err != nil {
 		exitOnErr(logger, err, "intersect failed")
 	} else {

--- a/examples/sender/main.go
+++ b/examples/sender/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"io"
 	"log"
+	"math"
 	"net"
 	"os"
 	"runtime"
@@ -34,7 +35,7 @@ func showUsageAndExit(exitcode int) {
 func memUsageToStdErr(logger logr.Logger) {
 	var m runtime.MemStats
 	runtime.ReadMemStats(&m) // https://cs.opensource.google/go/go/+/go1.17.1:src/runtime/mstats.go;l=107
-	logger.V(1).Info("Final stats", "total memory", m.Sys)
+	logger.V(1).Info("Final stats", "total memory (GiB)", math.Round(float64(m.Sys)*100/(1024*1024*1024))/100)
 	logger.V(1).Info("Final stats", "garbage collector calls", m.NumGC)
 }
 

--- a/examples/sender/main.go
+++ b/examples/sender/main.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"runtime"
 
+	"github.com/go-logr/logr"
+	"github.com/go-logr/stdr"
 	"github.com/optable/match/internal/util"
 	"github.com/optable/match/pkg/psi"
 )
@@ -36,10 +38,35 @@ func memUsageToStdErr() {
 	log.Printf("Garbage collector calls: %v\n", m.NumGC)
 }
 
+func exitOnErr(logger logr.Logger, err error, msg string) {
+	if err != nil {
+		logger.Error(err, msg)
+		os.Exit(1)
+	}
+}
+
+// getLogger returns a stdr.Logger that implements the logr.Logger interface
+// and sets the verbosity of the returned logger.
+// set v to 0 for info level messages,
+// 1 for debug messages and 2 for trace level message.
+// any other verbosity level will default to 0.
+func getLogger(v int) logr.Logger {
+	logger := stdr.New(nil)
+	// bound check
+	if v > 2 || v < 0 {
+		v = 0
+		logger.Info("Invalid verbosity, setting logger to display info level messages only.")
+	}
+	stdr.SetVerbosity(v)
+
+	return logger
+}
+
 func main() {
 	var protocol = flag.String("proto", defaultProtocol, "the psi protocol (bpsi,npsi,dhpsi,kkrt)")
 	var addr = flag.String("a", defaultAddress, "The receiver address")
 	var file = flag.String("in", defaultSenderFileName, "A list of IDs terminated with a newline")
+	var verbose = flag.Int("v", 0, "Verbosity level, default to -v 0 for info level messages, -v 1 for debug messages, and -v 2 for trace level message.")
 	var showHelp = flag.Bool("h", false, "Show help message")
 
 	log.SetFlags(0)
@@ -67,39 +94,34 @@ func main() {
 	}
 
 	log.Printf("operating with protocol %s", *protocol)
+	// fetch stdr logger
+	slog := getLogger(*verbose)
 
 	// open file
 	f, err := os.Open(*file)
-	if err != nil {
-		log.Fatal(err)
-	}
+	exitOnErr(slog, err, "failed to open file")
 
 	// count lines
 	log.Printf("counting lines in %s", *file)
 	n, err := util.Count(f)
-	if err != nil {
-		log.Fatal(err)
-	}
+	exitOnErr(slog, err, "failed to count")
 	log.Printf("operating on %s with %d IDs", *file, n)
 
 	// rewind
 	f.Seek(0, io.SeekStart)
 
 	c, err := net.Dial("tcp", *addr)
-	if err != nil {
-		log.Fatal(err)
-	}
+	exitOnErr(slog, err, "failed to dial")
 	defer c.Close()
 	// enable nagle
 	switch v := c.(type) {
 	case *net.TCPConn:
 		v.SetNoDelay(false)
 	}
+
 	s, _ := psi.NewSender(psiType, c)
 	ids := util.Exhaust(n, f)
-	err = s.Send(context.Background(), n, ids)
-	if err != nil {
-		log.Fatal(err)
-	}
+	err = s.Send(logr.NewContext(context.Background(), slog), n, ids)
+	exitOnErr(slog, err, "failed to perform PSI")
 	memUsageToStdErr()
 }

--- a/examples/sender/main.go
+++ b/examples/sender/main.go
@@ -31,11 +31,11 @@ func showUsageAndExit(exitcode int) {
 	os.Exit(exitcode)
 }
 
-func memUsageToStdErr() {
+func memUsageToStdErr(logger logr.Logger) {
 	var m runtime.MemStats
 	runtime.ReadMemStats(&m) // https://cs.opensource.google/go/go/+/go1.17.1:src/runtime/mstats.go;l=107
-	log.Printf("Total memory: %v\n", m.Sys)
-	log.Printf("Garbage collector calls: %v\n", m.NumGC)
+	logger.V(1).Info("Final stats", "total memory", m.Sys)
+	logger.V(1).Info("Final stats", "garbage collector calls", m.NumGC)
 }
 
 func exitOnErr(logger logr.Logger, err error, msg string) {
@@ -123,5 +123,5 @@ func main() {
 	ids := util.Exhaust(n, f)
 	err = s.Send(logr.NewContext(context.Background(), slog), n, ids)
 	exitOnErr(slog, err, "failed to perform PSI")
-	memUsageToStdErr()
+	memUsageToStdErr(slog)
 }

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,8 @@ require (
 	github.com/bits-and-blooms/bloom/v3 v3.0.1
 	github.com/bwesterb/go-ristretto v1.2.0
 	github.com/devopsfaith/bloomfilter v1.4.0
+	github.com/go-logr/logr v1.2.0
+	github.com/go-logr/stdr v1.2.0
 	github.com/gtank/ristretto255 v0.1.2
 	github.com/minio/highwayhash v1.0.2
 	github.com/twmb/murmur3 v1.1.6

--- a/go.sum
+++ b/go.sum
@@ -69,6 +69,10 @@ github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2
 github.com/go-ldap/ldap v3.0.2+incompatible/go.mod h1:qfd9rJvER9Q0/D/Sqn1DfHRoBp40uXYvFoEVrNEPqRc=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
+github.com/go-logr/logr v1.2.0 h1:QK40JKJyMdUDz+h+xvCsru/bJhvG0UxvePV0ufL/AcE=
+github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/go-logr/stdr v1.2.0 h1:j4LrlVXgrbIWO83mmQUnK0Hi+YnbD+vzrE1z/EphbFE=
+github.com/go-logr/stdr v1.2.0/go.mod h1:YkVgnZu1ZjjL7xTxrfm/LLZBfkhTqSR1ydtm6jTKKwI=
 github.com/go-ole/go-ole v1.2.1/go.mod h1:7FAglXiTm7HKlQRDeOQ6ZNUHidzCWXuZWq/1dTyBNF8=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=

--- a/pkg/bpsi/receiver.go
+++ b/pkg/bpsi/receiver.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/go-logr/logr"
 	"github.com/optable/match/internal/util"
 )
 
@@ -31,22 +32,36 @@ func NewReceiver(rw io.ReadWriter) *Receiver {
 // The format of an indentifier is
 //  string
 func (r *Receiver) Intersect(ctx context.Context, n int64, identifiers <-chan []byte) (intersected [][]byte, err error) {
+	// fetch and set up logger
+	logger := logr.FromContextOrDiscard(ctx)
+	logger = logger.WithValues("protocol", "bpsi")
 	var bf bloomfilter
 
 	// stage 1: read the bloomfilter from the remote side
 	stage1 := func() error {
-		bf, _, err = ReadFrom(r.rw)
-		return err
+		logger.V(1).Info("Starting stage 1")
+
+		_bf, _, err := ReadFrom(r.rw)
+		if err != nil {
+			return err
+		}
+		bf = _bf
+
+		logger.V(1).Info("Finished stage 1")
+		return nil
 	}
 
 	// stage 2: read local IDs and compare with the remote bloomfilter
 	//          to produce intersections
 	stage2 := func() error {
+		logger.V(1).Info("Starting stage 2")
 		for identifier := range identifiers {
 			if bf.Check(identifier) {
 				intersected = append(intersected, identifier)
 			}
 		}
+
+		logger.V(1).Info("Finished stage 2")
 		return nil
 	}
 
@@ -60,5 +75,6 @@ func (r *Receiver) Intersect(ctx context.Context, n int64, identifiers <-chan []
 		return intersected, err
 	}
 
+	logger.V(1).Info("receiver finished", "intersected", len(intersected))
 	return intersected, nil
 }

--- a/pkg/bpsi/sender.go
+++ b/pkg/bpsi/sender.go
@@ -66,6 +66,6 @@ func (s *Sender) Send(ctx context.Context, n int64, identifiers <-chan []byte) e
 		return err
 	}
 
-	logger.V(1).Info("sender finished.")
+	logger.V(1).Info("sender finished")
 	return nil
 }

--- a/pkg/bpsi/sender.go
+++ b/pkg/bpsi/sender.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 
+	"github.com/go-logr/logr"
 	"github.com/optable/match/internal/util"
 )
 
@@ -28,19 +29,30 @@ func NewSender(rw io.ReadWriter) *Sender {
 // example:
 //  0e1f461bbefa6e07cc2ef06b9ee1ed25101e24d4345af266ed2f5a58bcd26c5e
 func (s *Sender) Send(ctx context.Context, n int64, identifiers <-chan []byte) error {
+	// fetch and set up logger
+	logger := logr.FromContextOrDiscard(ctx)
+	logger = logger.WithValues("protocol", "bpsi")
+
 	// pick a bloomfilter implementation
 	s.bf, _ = NewBloomfilter(BloomfilterTypeBitsAndBloom, n)
 	// stage 1: load all local IDs into a bloom filter
 	stage1 := func() error {
+		logger.V(1).Info("Starting stage 1")
+
 		for id := range identifiers {
 			s.bf.Add(id)
 		}
+
+		logger.V(1).Info("Finished stage 1")
 		return nil
 	}
 
 	// stage 2: serialize the bloomfilter out into rw
 	stage2 := func() error {
+		logger.V(1).Info("Starting stage 2")
 		_, err := s.bf.WriteTo(s.rw)
+
+		logger.V(1).Info("Finished stage 2")
 		return err
 	}
 
@@ -54,5 +66,6 @@ func (s *Sender) Send(ctx context.Context, n int64, identifiers <-chan []byte) e
 		return err
 	}
 
+	logger.V(1).Info("sender finished.")
 	return nil
 }

--- a/pkg/dhpsi/receiver.go
+++ b/pkg/dhpsi/receiver.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/go-logr/logr"
 	"github.com/optable/match/internal/permutations"
 	"github.com/optable/match/internal/util"
 )
@@ -45,6 +46,10 @@ func (s *Receiver) IntersectFromReader(ctx context.Context, n int64, r io.Reader
 // The format of an indentifier is
 //  string
 func (s *Receiver) Intersect(ctx context.Context, n int64, identifiers <-chan []byte) ([][]byte, error) {
+	// fetch and set up logger
+	logger := logr.FromContextOrDiscard(ctx)
+	logger = logger.WithValues("protocol", "dhpsi")
+
 	// state
 	var remoteIDs = make(map[[EncodedLen]byte]bool) // single write goroutine access from stage1
 	var localIDs = make([][]byte, n)
@@ -62,25 +67,30 @@ func (s *Receiver) Intersect(ctx context.Context, n int64, identifiers <-chan []
 	gr, _ := NewRistretto(RistrettoTypeR255)
 	// step1 : reads the identifiers from the sender, encrypts them and indexes the encoded ristretto point in a map
 	stage1 := func() error {
-		reader, err := NewMultiplyParallelReader(s.rw, gr)
-		if err != nil {
+		logger.V(1).Info("Starting stage 1")
+
+		if reader, err := NewMultiplyParallelReader(s.rw, gr); err != nil {
 			return err
-		}
-		for {
-			// read
-			var p [EncodedLen]byte
-			if err := reader.Read(&p); err != nil {
-				if err == io.EOF {
-					return nil
+		} else {
+			for {
+				// read
+				var p [EncodedLen]byte
+				if err := reader.Read(&p); err != nil {
+					if err == io.EOF {
+						logger.V(1).Info("Finished stage 1")
+						return nil
+					}
+					return err
 				}
-				return err
+				// index
+				remoteIDs[p] = true
 			}
-			// index
-			remoteIDs[p] = true
 		}
 	}
 	// stage2.1 : permute and write the local identifiers to the sender
 	stage21 := func() error {
+		logger.V(1).Info("Starting stage 2.1")
+
 		writer, err := NewDeriveMultiplyParallelShuffler(s.rw, n, gr)
 		if err != nil {
 			return err
@@ -101,10 +111,12 @@ func (s *Receiver) Intersect(ctx context.Context, n int64, identifiers <-chan []
 			i++
 		}
 
+		logger.V(1).Info("Finished stage 2.1")
 		return nil
 	}
 	// step3: reads back the identifiers from the sender and learns the intersection
 	stage22 := func() error {
+		logger.V(1).Info("Starting stage 2.2")
 		reader, err := NewReader(s.rw)
 		if err != nil {
 			return err
@@ -123,6 +135,7 @@ func (s *Receiver) Intersect(ctx context.Context, n int64, identifiers <-chan []
 			}
 		}
 
+		logger.V(1).Info("Finished stage 2.2")
 		return nil
 	}
 
@@ -153,5 +166,6 @@ func (s *Receiver) Intersect(ctx context.Context, n int64, identifiers <-chan []
 		}
 	}
 
+	logger.V(1).Info("receiver finished", "intersected", len(intersection))
 	return intersection, nil
 }

--- a/pkg/dhpsi/sender.go
+++ b/pkg/dhpsi/sender.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/go-logr/logr"
 	"github.com/optable/match/internal/util"
 )
 
@@ -41,10 +42,16 @@ func (s *Sender) SendFromReader(ctx context.Context, n int64, r io.Reader) error
 // example:
 //  0e1f461bbefa6e07cc2ef06b9ee1ed25101e24d4345af266ed2f5a58bcd26c5e
 func (s *Sender) Send(ctx context.Context, n int64, identifiers <-chan []byte) error {
+	// fetch and set up logger
+	logger := logr.FromContextOrDiscard(ctx)
+	logger = logger.WithValues("protocol", "dhpsi")
+
 	// pick a ristretto implementation
 	gr, _ := NewRistretto(RistrettoTypeR255)
 	// stage1 : writes the permutated identifiers to the receiver
 	stage1 := func() error {
+		logger.V(1).Info("Starting stage 1")
+
 		writer, err := NewDeriveMultiplyParallelShuffler(s.rw, n, gr)
 		if err != nil {
 			return err
@@ -58,11 +65,15 @@ func (s *Sender) Send(ctx context.Context, n int64, identifiers <-chan []byte) e
 				return err
 			}
 		}
+
+		logger.V(1).Info("Finished stage 1")
 		return nil
 	}
 
 	// stage2 : reads the identifiers from the receiver, encrypts them and sends them back
 	stage2 := func() error {
+		logger.V(1).Info("Starting stage 2")
+
 		reader, err := NewMultiplyParallelReader(s.rw, gr)
 		if err != nil {
 			return err
@@ -82,6 +93,8 @@ func (s *Sender) Send(ctx context.Context, n int64, identifiers <-chan []byte) e
 				return fmt.Errorf("stage2: %v", err)
 			}
 		}
+
+		logger.V(1).Info("Finished stage 2")
 		return nil
 	}
 
@@ -94,5 +107,6 @@ func (s *Sender) Send(ctx context.Context, n int64, identifiers <-chan []byte) e
 		return err
 	}
 
+	logger.V(1).Info("sender finished")
 	return nil
 }

--- a/pkg/kkrtpsi/kkrtpsi.go
+++ b/pkg/kkrtpsi/kkrtpsi.go
@@ -2,8 +2,8 @@ package kkrtpsi
 
 import (
 	"encoding/binary"
-	"fmt"
 	"io"
+	"math"
 	"runtime"
 	"sync"
 	"time"
@@ -129,7 +129,7 @@ func printStageStats(log logr.Logger, stage int, prevTime, startTime time.Time, 
 	log.V(2).Info("stats", "stage", stage, "time", time.Since(prevTime).String(), "cumulative time", time.Since(startTime).String())
 	var m runtime.MemStats
 	runtime.ReadMemStats(&m) // https://cs.opensource.google/go/go/+/go1.17.1:src/runtime/mstats.go;l=107
-	log.V(2).Info("stats", "stage", stage, "total memory from OS", fmt.Sprintf("%v MiB", (m.Sys-prevMem)/(1024*1024)))
+	log.V(2).Info("stats", "stage", stage, "total memory from OS (MiB)", math.Round(float64(m.Sys-prevMem)*100/(1024*1024))/100)
 	//fmt.Printf("Heap Alloc: %v MiB\n", m.HeapAlloc/(1024*1024))
 	//fmt.Printf("Heap Sys: %v MiB\n", m.HeapSys/(1024*1024))           // estimate largest size heap has had
 	//fmt.Printf("Total Cum Alloc: %v MiB\n", m.TotalAlloc/(1024*1024)) // cumulative heap allocations

--- a/pkg/kkrtpsi/kkrtpsi.go
+++ b/pkg/kkrtpsi/kkrtpsi.go
@@ -130,9 +130,6 @@ func printStageStats(log logr.Logger, stage int, prevTime, startTime time.Time, 
 	var m runtime.MemStats
 	runtime.ReadMemStats(&m) // https://cs.opensource.google/go/go/+/go1.17.1:src/runtime/mstats.go;l=107
 	log.V(2).Info("stats", "stage", stage, "total memory from OS (MiB)", math.Round(float64(m.Sys-prevMem)*100/(1024*1024))/100)
-	//fmt.Printf("Heap Alloc: %v MiB\n", m.HeapAlloc/(1024*1024))
-	//fmt.Printf("Heap Sys: %v MiB\n", m.HeapSys/(1024*1024))           // estimate largest size heap has had
-	//fmt.Printf("Total Cum Alloc: %v MiB\n", m.TotalAlloc/(1024*1024)) // cumulative heap allocations
 	log.V(2).Info("stats", "stage", stage, "cumulative GC calls", m.NumGC)
 	return endTime, m.Sys
 }

--- a/pkg/kkrtpsi/kkrtpsi.go
+++ b/pkg/kkrtpsi/kkrtpsi.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/optable/match/internal/cuckoo"
 	"github.com/optable/match/internal/hash"
 	"github.com/optable/match/internal/oprf"
@@ -123,17 +124,15 @@ func EncodeAndHashAllParallel(oprfKeys oprf.Key, hasher hash.Hasher, identifiers
 	return encoded
 }
 
-func printStageStats(stage string, prevTime, startTime time.Time, prevMem uint64) (time.Time, uint64) {
-	fmt.Println("====================================")
-	fmt.Println(stage)
+func printStageStats(log logr.Logger, stage int, prevTime, startTime time.Time, prevMem uint64) (time.Time, uint64) {
 	endTime := time.Now()
-	fmt.Println("Time:\033[34;1m", endTime.Sub(prevTime), "\033[0m(cum", endTime.Sub(startTime), ")")
+	log.V(2).Info("stats", "stage", stage, "time", time.Since(prevTime).String(), "cumulative time", time.Since(startTime).String())
 	var m runtime.MemStats
 	runtime.ReadMemStats(&m) // https://cs.opensource.google/go/go/+/go1.17.1:src/runtime/mstats.go;l=107
-	fmt.Printf("Total memory from OS: \033[31;1m%v MiB\033[0m\n", (m.Sys-prevMem)/(1024*1024))
-	fmt.Printf("Heap Alloc: %v MiB\n", m.HeapAlloc/(1024*1024))
-	fmt.Printf("Heap Sys: %v MiB\n", m.HeapSys/(1024*1024))           // estimate largest size heap has had
-	fmt.Printf("Total Cum Alloc: %v MiB\n", m.TotalAlloc/(1024*1024)) // cumulative heap allocations
-	fmt.Printf("Cum NumGC calls: \033[33;1m%v\033[0m\n", m.NumGC)
+	log.V(2).Info("stats", "stage", stage, "total memory from OS", fmt.Sprintf("%v MiB", (m.Sys-prevMem)/(1024*1024)))
+	//fmt.Printf("Heap Alloc: %v MiB\n", m.HeapAlloc/(1024*1024))
+	//fmt.Printf("Heap Sys: %v MiB\n", m.HeapSys/(1024*1024))           // estimate largest size heap has had
+	//fmt.Printf("Total Cum Alloc: %v MiB\n", m.TotalAlloc/(1024*1024)) // cumulative heap allocations
+	log.V(2).Info("stats", "stage", stage, "cumulative GC calls", m.NumGC)
 	return endTime, m.Sys
 }

--- a/pkg/npsi/sender.go
+++ b/pkg/npsi/sender.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/go-logr/logr"
 	"github.com/optable/match/internal/hash"
 	"github.com/optable/match/internal/util"
 )
@@ -30,20 +31,28 @@ func NewSender(rw io.ReadWriter) *Sender {
 // example:
 //  0e1f461bbefa6e07cc2ef06b9ee1ed25101e24d4345af266ed2f5a58bcd26c5e
 func (s *Sender) Send(ctx context.Context, n int64, identifiers <-chan []byte) error {
+	// fetch and set up logger
+	logger := logr.FromContextOrDiscard(ctx)
+	logger = logger.WithValues("protocol", "npsi")
+
 	// hold k
 	var k = make([]byte, hash.SaltLength)
 	// stage 1: receive a random salt K from P1
 	stage1 := func() error {
+		logger.V(1).Info("Starting stage 1")
 		if n, err := s.rw.Read(k); err != nil {
 			return fmt.Errorf("stage1: %v", err)
 		} else if n != hash.SaltLength {
 			return hash.ErrSaltLengthMismatch
 		}
+
+		logger.V(1).Info("Finished stage 1")
 		return nil
 	}
 
 	// stage 2: send hashes salted with K to P1
 	stage2 := func() error {
+		logger.V(1).Info("Starting stage 2")
 		// get a hasher
 		h, err := hash.New(hash.Highway, k)
 		if err != nil {
@@ -62,6 +71,8 @@ func (s *Sender) Send(ctx context.Context, n int64, identifiers <-chan []byte) e
 				return fmt.Errorf("stage2: %v", err)
 			}
 		}
+
+		logger.V(1).Info("Finished stage 2")
 		return nil
 	}
 
@@ -74,5 +85,6 @@ func (s *Sender) Send(ctx context.Context, n int64, identifiers <-chan []byte) e
 		return err
 	}
 
+	logger.V(1).Info("sender finished")
 	return nil
 }


### PR DESCRIPTION
This silences the excessive stats logging during tests.
From the sender side, with verbosity 1 : `-v 1`
```bash
2021/11/18 17:31:02 "level"=1 "msg"="Starting stage 1" "protocol"="kkrtpsi"
2021/11/18 17:31:02 "level"=1 "msg"="Finished stage 1" "protocol"="kkrtpsi"
2021/11/18 17:31:02 "level"=1 "msg"="Starting stage 2" "protocol"="kkrtpsi"
2021/11/18 17:31:02 "level"=1 "msg"="Finished stage 2" "protocol"="kkrtpsi"
2021/11/18 17:31:02 "level"=1 "msg"="Starting stage 3" "protocol"="kkrtpsi"
2021/11/18 17:31:02 "level"=1 "msg"="Finished stage 3" "protocol"="kkrtpsi"
2021/11/18 17:31:02 "level"=1 "msg"="Final stats" "total memory"=74466312
2021/11/18 17:31:02 "level"=1 "msg"="Final stats" "garbage collector calls"=1
```

with verbosity 2: `-v 2`
```bash
2021/11/18 17:31:15 "level"=1 "msg"="Starting stage 1" "protocol"="kkrtpsi"
2021/11/18 17:31:15 "level"=2 "msg"="stats" "protocol"="kkrtpsi" "stage"=1 "time"="349.476µs" "cumulative time"="349.883µs"
2021/11/18 17:31:15 "level"=2 "msg"="stats" "protocol"="kkrtpsi" "stage"=1 "total memory from OS"="68 MiB"
2021/11/18 17:31:15 "level"=2 "msg"="stats" "protocol"="kkrtpsi" "stage"=1 "cumulative GC calls"=0
2021/11/18 17:31:15 "level"=1 "msg"="Finished stage 1" "protocol"="kkrtpsi"
2021/11/18 17:31:15 "level"=1 "msg"="Starting stage 2" "protocol"="kkrtpsi"
2021/11/18 17:31:15 "level"=2 "msg"="stats" "protocol"="kkrtpsi" "stage"=2 "time"="79.484832ms" "cumulative time"="79.835201ms"
2021/11/18 17:31:15 "level"=2 "msg"="stats" "protocol"="kkrtpsi" "stage"=2 "total memory from OS"="1 MiB"
2021/11/18 17:31:15 "level"=2 "msg"="stats" "protocol"="kkrtpsi" "stage"=2 "cumulative GC calls"=1
2021/11/18 17:31:15 "level"=1 "msg"="Finished stage 2" "protocol"="kkrtpsi"
2021/11/18 17:31:15 "level"=1 "msg"="Starting stage 3" "protocol"="kkrtpsi"
2021/11/18 17:31:15 "level"=2 "msg"="stats" "protocol"="kkrtpsi" "stage"=3 "time"="282.334µs" "cumulative time"="80.116871ms"
2021/11/18 17:31:15 "level"=2 "msg"="stats" "protocol"="kkrtpsi" "stage"=3 "total memory from OS"="0 MiB"
2021/11/18 17:31:15 "level"=2 "msg"="stats" "protocol"="kkrtpsi" "stage"=3 "cumulative GC calls"=1
2021/11/18 17:31:15 "level"=1 "msg"="Finished stage 3" "protocol"="kkrtpsi"
2021/11/18 17:31:15 "level"=1 "msg"="Final stats" "total memory"=74466312
2021/11/18 17:31:15 "level"=1 "msg"="Final stats" "garbage collector calls"=1
```

With no verbose mode, the above message won't show.