### PR TITLE
close downstream channel when reader encounters an error

### DIFF
--- a/pkg/dhpsi/dhpsi_parallel.go
+++ b/pkg/dhpsi/dhpsi_parallel.go
@@ -212,6 +212,7 @@ func fill(r *Reader, gr Ristretto) <-chan [EncodedLen]byte {
 				err := r.Read(&b.batch[j])
 				if err != nil {
 					// cancel everything
+					close(batches)
 					close(closed)
 					return
 				}


### PR DESCRIPTION
Now when we close sender at stage 1:
```
2021/11/30 10:23:19 "level"=1 "msg"="Starting stage 1" "protocol"="dhpsi"
intersect failed (0): unexpected EOF
```