### PR TITLE
Property-based testing of matrix transposition

### DIFF
--- a/internal/util/bits.go
+++ b/internal/util/bits.go
@@ -200,13 +200,6 @@ func BitExtract(b []byte, i int) byte {
 	return 0
 }
 
-// IsBitSetUint64 returns true if bit i is set in a uint64 slice.
-// It extracts bits from the least significant bit (i = 0) to the
-// most significant bit (i = 63).
-func IsBitSetUint64(u []uint64, i int) bool {
-	return u[i/64]&(1<<(i%64)) > 0
-}
-
 // SampleRandomBitMatrix allocates a 2D byte matrix of dimension row x col,
 // and adds extra rows of 0s to have the number of rows be a multiple of 512,
 // fills each entry in the byte matrix with pseudorandom byte values from a rand reader.
@@ -214,7 +207,7 @@ func SampleRandomBitMatrix(row, col int) ([][]uint8, error) {
 	// instantiate matrix
 	matrix := make([][]uint8, row)
 	for row := range matrix {
-		matrix[row] = make([]uint8, (col+Pad(col, 512))/8)
+		matrix[row] = make([]uint8, (col+Pad(col, bitVectWidth))/8)
 	}
 	// fill matrix
 	for row := range matrix {

--- a/internal/util/bits.go
+++ b/internal/util/bits.go
@@ -200,6 +200,13 @@ func BitExtract(b []byte, i int) byte {
 	return 0
 }
 
+// IsBitSetUint64 returns true if bit i is set in a uint64 slice.
+// It extracts bits from the least significant bit (i = 0) to the
+// most significant bit (i = 63).
+func IsBitSetUint64(u []uint64, i int) bool {
+	return u[i/64]&(1<<(i%64)) > 0
+}
+
 // SampleRandomBitMatrix allocates a 2D byte matrix of dimension row x col,
 // and adds extra rows of 0s to have the number of rows be a multiple of 512,
 // fills each entry in the byte matrix with pseudorandom byte values from a rand reader.

--- a/internal/util/bits_test.go
+++ b/internal/util/bits_test.go
@@ -5,13 +5,14 @@ import (
 	"reflect"
 	"testing"
 	"testing/quick"
+	"time"
 )
 
 const benchmarkBytes = 1000000
 
-func genBytes(size int) []byte {
+func genBytes(size int, r *rand.Rand) []byte {
 	bytes := make([]byte, size)
-	if _, err := rand.Read(bytes); err != nil {
+	if _, err := r.Read(bytes); err != nil {
 		panic("error generating random bytes")
 	}
 
@@ -27,12 +28,13 @@ type bitSets struct {
 
 // Generate creates a bitSets struct with three byte slices of
 // equal length
-func (bitSets) Generate(r *rand.Rand, size int) reflect.Value {
+func (bitSets) Generate(r *rand.Rand, unusedSizeHint int) reflect.Value {
 	var sets bitSets
+	size := r.Intn(benchmarkBytes)
 	sets.Scratch = make([]byte, size)
-	sets.A = genBytes(size)
-	sets.B = genBytes(size)
-	sets.C = genBytes(size)
+	sets.A = genBytes(size, r)
+	sets.B = genBytes(size, r)
+	sets.C = genBytes(size, r)
 	return reflect.ValueOf(sets)
 }
 
@@ -381,8 +383,9 @@ func TestTestBitSetInByte(t *testing.T) {
 }
 
 func BenchmarkXor(b *testing.B) {
-	src := genBytes(benchmarkBytes)
-	dst := genBytes(benchmarkBytes)
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	src := genBytes(benchmarkBytes, r)
+	dst := genBytes(benchmarkBytes, r)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		Xor(dst, src)
@@ -390,8 +393,9 @@ func BenchmarkXor(b *testing.B) {
 }
 
 func BenchmarkAnd(b *testing.B) {
-	src := genBytes(benchmarkBytes)
-	dst := genBytes(benchmarkBytes)
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	src := genBytes(benchmarkBytes, r)
+	dst := genBytes(benchmarkBytes, r)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		And(dst, src)
@@ -399,9 +403,10 @@ func BenchmarkAnd(b *testing.B) {
 }
 
 func BenchmarkDoubleXor(b *testing.B) {
-	src := genBytes(benchmarkBytes)
-	src2 := genBytes(benchmarkBytes)
-	dst := genBytes(benchmarkBytes)
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	src := genBytes(benchmarkBytes, r)
+	src2 := genBytes(benchmarkBytes, r)
+	dst := genBytes(benchmarkBytes, r)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		DoubleXor(dst, src, src2)
@@ -409,9 +414,10 @@ func BenchmarkDoubleXor(b *testing.B) {
 }
 
 func BenchmarkAndXor(b *testing.B) {
-	src := genBytes(benchmarkBytes)
-	src2 := genBytes(benchmarkBytes)
-	dst := genBytes(benchmarkBytes)
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	src := genBytes(benchmarkBytes, r)
+	src2 := genBytes(benchmarkBytes, r)
+	dst := genBytes(benchmarkBytes, r)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		AndXor(dst, src, src2)
@@ -419,8 +425,9 @@ func BenchmarkAndXor(b *testing.B) {
 }
 
 func BenchmarkConcurrentBitOp(b *testing.B) {
-	src := genBytes(benchmarkBytes)
-	dst := genBytes(benchmarkBytes)
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	src := genBytes(benchmarkBytes, r)
+	dst := genBytes(benchmarkBytes, r)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		ConcurrentBitOp(Xor, dst, src)
@@ -428,9 +435,10 @@ func BenchmarkConcurrentBitOp(b *testing.B) {
 }
 
 func BenchmarkConcurrentDoubleBitOp(b *testing.B) {
-	src := genBytes(benchmarkBytes)
-	src2 := genBytes(benchmarkBytes)
-	dst := genBytes(benchmarkBytes)
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	src := genBytes(benchmarkBytes, r)
+	src2 := genBytes(benchmarkBytes, r)
+	dst := genBytes(benchmarkBytes, r)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		ConcurrentDoubleBitOp(AndXor, dst, src, src2)

--- a/internal/util/bitvect_test.go
+++ b/internal/util/bitvect_test.go
@@ -68,9 +68,9 @@ type tallMatrix struct {
 // Generate creates a struct containing a pseudorandom
 // tall matrix which has 512 columns and a multiple of
 // 512 rows.
-func (tallMatrix) Generate(r *rand.Rand, unusedSizeHint int) reflect.Value {
+func (tallMatrix) Generate(r *rand.Rand, sizeHint int) reflect.Value {
 	var tall tallMatrix
-	size := 1 + r.Intn(5*bitVectWidth) // a max of 6 blocks
+	size := r.Intn(sizeHint*bitVectWidth) // max 32 blocks
 	tall.matrix = sampleRandomTall(Pad(size, bitVectWidth), r)
 	return reflect.ValueOf(tall)
 }
@@ -172,9 +172,9 @@ type wideMatrix struct {
 // Generate creates a struct containing a pseudorandom
 // wide matrix which has 512 rows and a multiple of
 // 512 columns.
-func (wideMatrix) Generate(r *rand.Rand, unusedSizeHint int) reflect.Value {
+func (wideMatrix) Generate(r *rand.Rand, sizeHint int) reflect.Value {
 	var wide wideMatrix
-	size := 1 + r.Intn(5*bitVectWidth) // a max of 6 blocks
+	size := r.Intn(sizeHint*bitVectWidth) // max 32 blocks
 	wide.matrix = sampleRandomWide(Pad(size, bitVectWidth), r)
 	return reflect.ValueOf(wide)
 }
@@ -238,7 +238,7 @@ func TestTransposeWide(t *testing.T) {
 	correct := func(m wideMatrix) bool {
 		tr := ConcurrentTransposeWide(m.matrix)
 		for r, row := range m.matrix {
-			for i := 0; i < bitVectWidth; i++ {
+			for i := 0; i < len(row); i++ {
 				if IsBitSet(row, i) != IsBitSet(tr[i], r) {
 					return false
 				}

--- a/internal/util/bitvect_test.go
+++ b/internal/util/bitvect_test.go
@@ -70,7 +70,7 @@ type tallMatrix struct {
 // 512 rows.
 func (tallMatrix) Generate(r *rand.Rand, unusedSizeHint int) reflect.Value {
 	var tall tallMatrix
-	size := 1 + r.Intn(5*bitVectWidth) // a max of 5 blocks
+	size := 1 + r.Intn(5*bitVectWidth) // a max of 6 blocks
 	tall.matrix = sampleRandomTall(Pad(size, bitVectWidth), r)
 	return reflect.ValueOf(tall)
 }
@@ -174,7 +174,7 @@ type wideMatrix struct {
 // 512 columns.
 func (wideMatrix) Generate(r *rand.Rand, unusedSizeHint int) reflect.Value {
 	var wide wideMatrix
-	size := 1 + r.Intn(5*bitVectWidth) // a max of 5 blocks
+	size := 1 + r.Intn(5*bitVectWidth) // a max of 6 blocks
 	wide.matrix = sampleRandomWide(Pad(size, bitVectWidth), r)
 	return reflect.ValueOf(wide)
 }


### PR DESCRIPTION
Rather than just testing the self-inverse property of matrix transposition, use property-based testing to check if transposition is correct and meets the self-inverse (involutory) property.

Similarly test unraveling and reraveling of matrices.

We still check that the transposition is performed in the Little Endian-sense with another test.