### PR TITLE
Replace nagle with bufio

### DIFF
--- a/examples/receiver/main.go
+++ b/examples/receiver/main.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"flag"
 	"io"
 	"log"
-	"net"
 	"os"
 	"sync"
 	"time"
@@ -22,6 +22,59 @@ const (
 	defaultSenderFileName = "receiver-ids.txt"
 	defaultCommonFileName = "common-ids.txt"
 )
+
+// example certs were generated from crypto/tls/generate_cert.go with the following command:
+//   go run $(go env GOROOT)/src/crypto/tls/generate_cert.go --rsa-bits 2048
+// --host 127.0.0.1,::1,example.com --ca --start-date "Jan 1 00:00:00 1970" --duration=1000000h
+var exampleCert = []byte(`-----BEGIN CERTIFICATE-----
+MIIDOjCCAiKgAwIBAgIRAPhLot3LxaigqdKikGI6PtgwDQYJKoZIhvcNAQELBQAw
+EjEQMA4GA1UEChMHQWNtZSBDbzAgFw03MDAxMDEwMDAwMDBaGA8yMDg0MDEyOTE2
+MDAwMFowEjEQMA4GA1UEChMHQWNtZSBDbzCCASIwDQYJKoZIhvcNAQEBBQADggEP
+ADCCAQoCggEBANzxrGrkW7X+MALttWLMVhpS5QmQBYgu1Vmj/2pu4w7XUVpKolyC
+ZahZBDug5p60w86kzDhLBuaRF5XypAmsCZQSB1decgkf7u3JHC2/RPyWINw/uAix
+kY8G3JC8Gpz+nVonlYpYON4WSQa1ZmZ2Vz8AO/qYfBJ525Dz0zf0UTgqi3gCyqzI
+/yWAhOhrxN5QbrXzLwSxG7EIejsNIp3W/PD1Cxxy1ljG3O4Po1zB9m9zh+dyaa1n
+zg9ltWKWrHtikYTzYkkE4KAvYRbQhRR2mdRALs/i4vmMkp8ZVGf2DD4mBPqyh4Do
+/0DrcCSiTVbKBXl4J+OeQKMZRhCMFFKBavUCAwEAAaOBiDCBhTAOBgNVHQ8BAf8E
+BAMCAqQwEwYDVR0lBAwwCgYIKwYBBQUHAwEwDwYDVR0TAQH/BAUwAwEB/zAdBgNV
+HQ4EFgQUZ+pstuWDZ6dcdGd/7dLl6GkXucowLgYDVR0RBCcwJYILZXhhbXBsZS5j
+b22HBH8AAAGHEAAAAAAAAAAAAAAAAAAAAAEwDQYJKoZIhvcNAQELBQADggEBAHcp
+MpqwqKIvcdNEFj9i7yCMPzteVfH5GZeOtO4Rglwn7TzYpJhvbZDzYPd9CkFVuIOo
+h+5wUTRDiT8rES9wxQ4qHjByGqzSoJ1oaIzcEsihWzdCvFzkzSjyCDgMesqnZM/6
+0nzz4ZnL8c+gf0IG18KEfJu3tvm17Jdbk1Y731mwrDoGy7MNxQVKsDT6+kMdP6FX
+BLwxFHGfQfq3EqIRtm8UCOaPzchn6iXveksbdXWPSK2Yk3sLX1wzqIYRA1Ia/dOR
+mOQqatUkit83UM5707DjkTxS5TJh+rsLRtKP04wtTLKUr0kjwNYPBnFhhs8bJoSW
+ltYQrxMCa6uPtEyQBi0=
+-----END CERTIFICATE-----`)
+
+var exampleKey = []byte(`-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDc8axq5Fu1/jAC
+7bVizFYaUuUJkAWILtVZo/9qbuMO11FaSqJcgmWoWQQ7oOaetMPOpMw4SwbmkReV
+8qQJrAmUEgdXXnIJH+7tyRwtv0T8liDcP7gIsZGPBtyQvBqc/p1aJ5WKWDjeFkkG
+tWZmdlc/ADv6mHwSeduQ89M39FE4Kot4AsqsyP8lgIToa8TeUG618y8EsRuxCHo7
+DSKd1vzw9QscctZYxtzuD6NcwfZvc4fncmmtZ84PZbVilqx7YpGE82JJBOCgL2EW
+0IUUdpnUQC7P4uL5jJKfGVRn9gw+JgT6soeA6P9A63Akok1WygV5eCfjnkCjGUYQ
+jBRSgWr1AgMBAAECggEANB6+saiVCeWgpdA1jczuMt+DMDJNW8bQhYjuY8ksvv+E
+LWyVyITqPkBhgz99p8q0tjaiBlWMly97BOBsWeu/hrKKEM4y0Hw7/NQIVbJdL8iq
+j8poO4TH9ZmExo/ZJ1fY/r9/w1b0c0+GgpKgSWN5SV9gxsjZ2/HrHdKm7PgxgLH4
+Z4dPK13JgPelz6c1prDCXhCWbmkZMnJg/w+0/ZmuIlublDMO6CK4rIy+b2Hd1vqv
+74PkxIc9XpZOYb7d3li117w+htgDs/03NVztBn7BykEHtHEhfFgDdTFvJe8A6msM
+7qyqOJey0KLkKZZ15f+VR3sb8NBB5LO7+SUhAJxcsQKBgQDtTuwBgh5hTr+MtWJD
+HsQtN5oICBgHzYXsGRGn1H51ECKGc9KM4WDXW3dCbBAS7HHTH7kywvqkXS8mfnmu
+yhNgfiECIgfS7F1mX0NKxSBBFX4auhHGqYGMBw1y0EFB5GpXJZXc4G3BXI95VgLe
+m87/cbmbj4lKoBQhaahdhBbcFwKBgQDuWMiEXrYxf5GhpCZ/ET4UmvqxPJbVCe79
+6hFnF8pk1sq8kIn6/aF83+9L4BCVzbYmRXDya9mw/CMimGKtVDSxtvk35XCGpfY5
+M1fvV0oFq03vbsHYMr3/Sb3IstO9zvhtfUHgQbuh5uoGoSRPMdlBZIikX4mOiUCc
+hgS64lSc0wKBgG3FIwAzmy/xyEMjJ/faRG6SGKr8a3k4hWlH01XpwjEOLJo6+zr1
+ieE0Sv8rk2fdfW1mcDld3ain/gZ1XH4QtVPeJBCjgzD66t1O1YbBloDkmzdruItH
+n0gRfxQL5xO+v73eAetw2PQnh6pdsegc9GxOw8eEZsJhN86Y3CudzSEzAoGAXEM/
+84WaL1T7cb/SKxPonR9U9bDHjlYXDnFCJU8fSKOgvReSYfc2QNmKjyuAIA0Oeogc
+7ap0DT+89hJY+FGFSFnU5R9KzMSHqKLIYly+ya0DMTEFloQl6iGIdp1Ku8nXfsKi
+8oVfdY+mfcR5ArMAL4EUJ9TXsbZNrYlvYUxlhoMCgYEAj46cxTcJJ8LKIj5sF/+j
+LpFjpum1QouSsB8CbscG+0OYS3Bs9Mfh0pGGR/hgjsg5+R4PRITfzJUEYnjtW4TL
+3AKbYyx2+W62SrtSv9p8yGJgdGLQaaJd4OaVDXCzllUAII3wRtB3YSUlGMpn9MkR
+rp4tfIxqa0W9QmmnenEgDj0=
+-----END PRIVATE KEY-----`)
 
 func usage() {
 	log.Printf("Usage: receiver [-proto protocol] [-p port] [-in file] [-out file] [-once false]\n")
@@ -81,9 +134,15 @@ func main() {
 	log.Printf("operating on %s with %d IDs", *file, n)
 
 	// get a listener
-	l, err := net.Listen("tcp", *port)
+	cert, err := tls.X509KeyPair(exampleCert, exampleKey)
+	if err != nil {
+		format.ExitOnErr(mlog, err, "failed to load certs")
+	}
+	conf := &tls.Config{Certificates: []tls.Certificate{cert}}
+	l, err := tls.Listen("tcp", *port, conf)
 	format.ExitOnErr(mlog, err, "failed to listen on tcp port")
 	log.Printf("receiver listening on %s", *port)
+	//defer l.Close()
 	for {
 		if c, err := l.Accept(); err != nil {
 			format.ExitOnErr(mlog, err, "failed to accept incoming connection")
@@ -91,11 +150,6 @@ func main() {
 			log.Printf("handling sender %s", c.RemoteAddr())
 			f, err := os.Open(*file)
 			format.ExitOnErr(mlog, err, "failed to open file")
-			// enable nagle
-			switch v := c.(type) {
-			case *net.TCPConn:
-				v.SetNoDelay(false)
-			}
 
 			// make the receiver
 			receiver, err := psi.NewReceiver(psiType, c)

--- a/examples/sender/main.go
+++ b/examples/sender/main.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"flag"
 	"io"
 	"log"
-	"net"
 	"os"
 
 	"github.com/go-logr/logr"
@@ -72,14 +72,12 @@ func main() {
 	// rewind
 	f.Seek(0, io.SeekStart)
 
-	c, err := net.Dial("tcp", *addr)
+	conf := &tls.Config{
+		InsecureSkipVerify: true,
+	}
+	c, err := tls.Dial("tcp", *addr, conf)
 	format.ExitOnErr(slog, err, "failed to dial")
 	defer c.Close()
-	// enable nagle
-	switch v := c.(type) {
-	case *net.TCPConn:
-		v.SetNoDelay(false)
-	}
 
 	s, err := psi.NewSender(psiType, c)
 	format.ExitOnErr(slog, err, "failed to create sender")

--- a/pkg/npsi/receiver.go
+++ b/pkg/npsi/receiver.go
@@ -1,6 +1,7 @@
 package npsi
 
 import (
+	"bufio"
 	"context"
 	"crypto/rand"
 	"encoding/binary"
@@ -17,13 +18,13 @@ import (
 
 // Receiver represents the receiver side of the NPSI protocol
 type Receiver struct {
-	rw io.ReadWriter
+	rw *bufio.ReadWriter
 }
 
 // NewReceiver returns a receiver initialized to
-// use rw as the communication layer
+// use rw as a buffered communication layer
 func NewReceiver(rw io.ReadWriter) *Receiver {
-	return &Receiver{rw: rw}
+	return &Receiver{rw: bufio.NewReadWriter(bufio.NewReader(rw), bufio.NewWriter(rw))}
 }
 
 // Intersect intersects on matchables read from the identifiers channel,
@@ -49,6 +50,7 @@ func (r *Receiver) Intersect(ctx context.Context, n int64, identifiers <-chan []
 		if _, err := r.rw.Write(k); err != nil {
 			return err
 		}
+		r.rw.Flush()
 
 		logger.V(1).Info("Finished stage 1")
 		return nil

--- a/pkg/npsi/sender.go
+++ b/pkg/npsi/sender.go
@@ -1,6 +1,7 @@
 package npsi
 
 import (
+	"bufio"
 	"context"
 	"encoding/binary"
 	"fmt"
@@ -16,13 +17,13 @@ import (
 
 // Sender represents sender side of the NPSI protocol
 type Sender struct {
-	rw io.ReadWriter
+	rw *bufio.ReadWriter
 }
 
 // NewSender returns a sender initialized to
-// use rw as the communication layer
+// use rw as a buffered communication layer
 func NewSender(rw io.ReadWriter) *Sender {
-	return &Sender{rw: rw}
+	return &Sender{rw: bufio.NewReadWriter(bufio.NewReader(rw), bufio.NewWriter(rw))}
 }
 
 // Send initiates a NPSI exchange
@@ -71,6 +72,7 @@ func (s *Sender) Send(ctx context.Context, n int64, identifiers <-chan []byte) e
 				return fmt.Errorf("stage2: %v", err)
 			}
 		}
+		s.rw.Flush()
 
 		logger.V(1).Info("Finished stage 2")
 		return nil

--- a/test/psi/receiver_test.go
+++ b/test/psi/receiver_test.go
@@ -3,6 +3,7 @@ package psi_test
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/hex"
 	"fmt"
 	"net"
@@ -13,9 +14,67 @@ import (
 	"github.com/optable/match/test/emails"
 )
 
+// example certs were generated from crypto/tls/generate_cert.go with the following command:
+//   go run $(go env GOROOT)/src/crypto/tls/generate_cert.go --rsa-bits 2048
+// --host 127.0.0.1,::1,example.com --ca --start-date "Jan 1 00:00:00 1970" --duration=1000000h
+var exampleCert = []byte(`-----BEGIN CERTIFICATE-----
+MIIDOjCCAiKgAwIBAgIRAPhLot3LxaigqdKikGI6PtgwDQYJKoZIhvcNAQELBQAw
+EjEQMA4GA1UEChMHQWNtZSBDbzAgFw03MDAxMDEwMDAwMDBaGA8yMDg0MDEyOTE2
+MDAwMFowEjEQMA4GA1UEChMHQWNtZSBDbzCCASIwDQYJKoZIhvcNAQEBBQADggEP
+ADCCAQoCggEBANzxrGrkW7X+MALttWLMVhpS5QmQBYgu1Vmj/2pu4w7XUVpKolyC
+ZahZBDug5p60w86kzDhLBuaRF5XypAmsCZQSB1decgkf7u3JHC2/RPyWINw/uAix
+kY8G3JC8Gpz+nVonlYpYON4WSQa1ZmZ2Vz8AO/qYfBJ525Dz0zf0UTgqi3gCyqzI
+/yWAhOhrxN5QbrXzLwSxG7EIejsNIp3W/PD1Cxxy1ljG3O4Po1zB9m9zh+dyaa1n
+zg9ltWKWrHtikYTzYkkE4KAvYRbQhRR2mdRALs/i4vmMkp8ZVGf2DD4mBPqyh4Do
+/0DrcCSiTVbKBXl4J+OeQKMZRhCMFFKBavUCAwEAAaOBiDCBhTAOBgNVHQ8BAf8E
+BAMCAqQwEwYDVR0lBAwwCgYIKwYBBQUHAwEwDwYDVR0TAQH/BAUwAwEB/zAdBgNV
+HQ4EFgQUZ+pstuWDZ6dcdGd/7dLl6GkXucowLgYDVR0RBCcwJYILZXhhbXBsZS5j
+b22HBH8AAAGHEAAAAAAAAAAAAAAAAAAAAAEwDQYJKoZIhvcNAQELBQADggEBAHcp
+MpqwqKIvcdNEFj9i7yCMPzteVfH5GZeOtO4Rglwn7TzYpJhvbZDzYPd9CkFVuIOo
+h+5wUTRDiT8rES9wxQ4qHjByGqzSoJ1oaIzcEsihWzdCvFzkzSjyCDgMesqnZM/6
+0nzz4ZnL8c+gf0IG18KEfJu3tvm17Jdbk1Y731mwrDoGy7MNxQVKsDT6+kMdP6FX
+BLwxFHGfQfq3EqIRtm8UCOaPzchn6iXveksbdXWPSK2Yk3sLX1wzqIYRA1Ia/dOR
+mOQqatUkit83UM5707DjkTxS5TJh+rsLRtKP04wtTLKUr0kjwNYPBnFhhs8bJoSW
+ltYQrxMCa6uPtEyQBi0=
+-----END CERTIFICATE-----`)
+
+var exampleKey = []byte(`-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDc8axq5Fu1/jAC
+7bVizFYaUuUJkAWILtVZo/9qbuMO11FaSqJcgmWoWQQ7oOaetMPOpMw4SwbmkReV
+8qQJrAmUEgdXXnIJH+7tyRwtv0T8liDcP7gIsZGPBtyQvBqc/p1aJ5WKWDjeFkkG
+tWZmdlc/ADv6mHwSeduQ89M39FE4Kot4AsqsyP8lgIToa8TeUG618y8EsRuxCHo7
+DSKd1vzw9QscctZYxtzuD6NcwfZvc4fncmmtZ84PZbVilqx7YpGE82JJBOCgL2EW
+0IUUdpnUQC7P4uL5jJKfGVRn9gw+JgT6soeA6P9A63Akok1WygV5eCfjnkCjGUYQ
+jBRSgWr1AgMBAAECggEANB6+saiVCeWgpdA1jczuMt+DMDJNW8bQhYjuY8ksvv+E
+LWyVyITqPkBhgz99p8q0tjaiBlWMly97BOBsWeu/hrKKEM4y0Hw7/NQIVbJdL8iq
+j8poO4TH9ZmExo/ZJ1fY/r9/w1b0c0+GgpKgSWN5SV9gxsjZ2/HrHdKm7PgxgLH4
+Z4dPK13JgPelz6c1prDCXhCWbmkZMnJg/w+0/ZmuIlublDMO6CK4rIy+b2Hd1vqv
+74PkxIc9XpZOYb7d3li117w+htgDs/03NVztBn7BykEHtHEhfFgDdTFvJe8A6msM
+7qyqOJey0KLkKZZ15f+VR3sb8NBB5LO7+SUhAJxcsQKBgQDtTuwBgh5hTr+MtWJD
+HsQtN5oICBgHzYXsGRGn1H51ECKGc9KM4WDXW3dCbBAS7HHTH7kywvqkXS8mfnmu
+yhNgfiECIgfS7F1mX0NKxSBBFX4auhHGqYGMBw1y0EFB5GpXJZXc4G3BXI95VgLe
+m87/cbmbj4lKoBQhaahdhBbcFwKBgQDuWMiEXrYxf5GhpCZ/ET4UmvqxPJbVCe79
+6hFnF8pk1sq8kIn6/aF83+9L4BCVzbYmRXDya9mw/CMimGKtVDSxtvk35XCGpfY5
+M1fvV0oFq03vbsHYMr3/Sb3IstO9zvhtfUHgQbuh5uoGoSRPMdlBZIikX4mOiUCc
+hgS64lSc0wKBgG3FIwAzmy/xyEMjJ/faRG6SGKr8a3k4hWlH01XpwjEOLJo6+zr1
+ieE0Sv8rk2fdfW1mcDld3ain/gZ1XH4QtVPeJBCjgzD66t1O1YbBloDkmzdruItH
+n0gRfxQL5xO+v73eAetw2PQnh6pdsegc9GxOw8eEZsJhN86Y3CudzSEzAoGAXEM/
+84WaL1T7cb/SKxPonR9U9bDHjlYXDnFCJU8fSKOgvReSYfc2QNmKjyuAIA0Oeogc
+7ap0DT+89hJY+FGFSFnU5R9KzMSHqKLIYly+ya0DMTEFloQl6iGIdp1Ku8nXfsKi
+8oVfdY+mfcR5ArMAL4EUJ9TXsbZNrYlvYUxlhoMCgYEAj46cxTcJJ8LKIj5sF/+j
+LpFjpum1QouSsB8CbscG+0OYS3Bs9Mfh0pGGR/hgjsg5+R4PRITfzJUEYnjtW4TL
+3AKbYyx2+W62SrtSv9p8yGJgdGLQaaJd4OaVDXCzllUAII3wRtB3YSUlGMpn9MkR
+rp4tfIxqa0W9QmmnenEgDj0=
+-----END PRIVATE KEY-----`)
+
 // test receiver and return the addr string
 func r_receiverInit(protocol psi.Protocol, common []byte, commonLen, receiverLen, hashLen int, intersectionsBus chan<- []byte, errs chan<- error) (addr string, err error) {
-	ln, err := net.Listen("tcp", "127.0.0.1:")
+	cert, err := tls.X509KeyPair(exampleCert, exampleKey)
+	if err != nil {
+		return "", err
+	}
+	conf := &tls.Config{Certificates: []tls.Certificate{cert}}
+	ln, err := tls.Listen("tcp", "127.0.0.1:", conf)
 	if err != nil {
 		return "", err
 	}
@@ -73,7 +132,10 @@ func testReceiver(protocol psi.Protocol, common []byte, s test_size, determinist
 	// send operation
 	go func() {
 		r := initTestDataSource(common, s.senderLen-s.commonLen, s.hashLen)
-		conn, err := net.Dial("tcp", addr)
+		conf := &tls.Config{
+			InsecureSkipVerify: true,
+		}
+		conn, err := tls.Dial("tcp", addr, conf)
 		if err != nil {
 			errs <- fmt.Errorf("sender: %v", err)
 		}


### PR DESCRIPTION
We currently establish a tcp connection and then enable nagle, and then get a TLS connection from the resulting TCP conn.
TLS doesn't allow settings for nagle and the PSI underperform without it.

Instead we can establish a TLS connection, and use bufio to buffer the connection to achieve the same effect.