### PR TITLE
Use bufio in NPSI

### DIFF
--- a/pkg/npsi/receiver.go
+++ b/pkg/npsi/receiver.go
@@ -1,6 +1,7 @@
 package npsi
 
 import (
+	"bufio"
 	"context"
 	"crypto/rand"
 	"encoding/binary"
@@ -17,13 +18,13 @@ import (
 
 // Receiver represents the receiver side of the NPSI protocol
 type Receiver struct {
-	rw io.ReadWriter
+	rw *bufio.ReadWriter
 }
 
 // NewReceiver returns a receiver initialized to
-// use rw as the communication layer
+// use rw as a buffered communication layer
 func NewReceiver(rw io.ReadWriter) *Receiver {
-	return &Receiver{rw: rw}
+	return &Receiver{rw: bufio.NewReadWriter(bufio.NewReader(rw), bufio.NewWriter(rw))}
 }
 
 // Intersect intersects on matchables read from the identifiers channel,
@@ -49,6 +50,7 @@ func (r *Receiver) Intersect(ctx context.Context, n int64, identifiers <-chan []
 		if _, err := r.rw.Write(k); err != nil {
 			return err
 		}
+		r.rw.Flush()
 
 		logger.V(1).Info("Finished stage 1")
 		return nil

--- a/pkg/npsi/sender.go
+++ b/pkg/npsi/sender.go
@@ -1,6 +1,7 @@
 package npsi
 
 import (
+	"bufio"
 	"context"
 	"encoding/binary"
 	"fmt"
@@ -16,13 +17,13 @@ import (
 
 // Sender represents sender side of the NPSI protocol
 type Sender struct {
-	rw io.ReadWriter
+	rw *bufio.ReadWriter
 }
 
 // NewSender returns a sender initialized to
 // use rw as the communication layer
 func NewSender(rw io.ReadWriter) *Sender {
-	return &Sender{rw: rw}
+	return &Sender{rw: bufio.NewReadWriter(bufio.NewReader(rw), bufio.NewWriter(rw))}
 }
 
 // Send initiates a NPSI exchange
@@ -71,6 +72,7 @@ func (s *Sender) Send(ctx context.Context, n int64, identifiers <-chan []byte) e
 				return fmt.Errorf("stage2: %v", err)
 			}
 		}
+		s.rw.Flush()
 
 		logger.V(1).Info("Finished stage 2")
 		return nil


### PR DESCRIPTION
Use `bufio` to buffer communication in NPSI protocol. This amortizes syscalls and could be used in conjunction with the
removal of nagle in the future.