### PR TITLE
fix: elliptic curve subtraction on proper ec points

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/optable/match
 
-go 1.16
+go 1.19
 
 require (
 	github.com/alecthomas/unsafeslice v0.1.0
@@ -13,5 +13,9 @@ require (
 	github.com/twmb/murmur3 v1.1.6
 	github.com/zeebo/blake3 v0.2.0
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
+)
+
+require (
+	github.com/bits-and-blooms/bitset v1.2.0 // indirect
 	golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/optable/match
 
-go 1.19
+go 1.16
 
 require (
 	github.com/alecthomas/unsafeslice v0.1.0
@@ -15,7 +15,4 @@ require (
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 )
 
-require (
-	github.com/bits-and-blooms/bitset v1.2.0 // indirect
-	golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf // indirect
-)
+require golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf // indirect

--- a/internal/crypto/point.go
+++ b/internal/crypto/point.go
@@ -68,8 +68,13 @@ func (p *Point) ScalarMult(scalar []byte) *Point {
 
 // Sub substracts point p from q
 func (p *Point) Sub(q *Point) *Point {
+	// in order to do point subtraction, we need to make sure
+	// the negative point is still mapped properly in the field elements.
+	negQy := new(big.Int).Neg(q.y)
+	negQy = negQy.Mod(negQy, curve.Params().P) // here P is the order of the curve field
+
 	// p - q = p.x + q.x, p.y - q.y
-	x, y := curve.Add(p.x, p.y, q.x, new(big.Int).Neg(q.y))
+	x, y := curve.Add(p.x, p.y, q.x, negQy)
 	return &Point{x: x, y: y}
 }
 


### PR DESCRIPTION
golang `crypto/elliptic` library's `IsOnCurve` no longer returns true for ec points with negative values. This is due to the fact that the ec points are defined on `[0, P)` where `P` is the prime order of the field. This leads to a panic when we call `curve.Add()` with a point that contains negative values. 

This wasn't an issue for us since the underlying `curve.Add()` operation simply operated on the coordinates of the curve points (addition on x, y coordinates), and we were not using the negative ec point directly, but rather the result of the addition with the negative points, which can be encoded/decoded properly.

The fix is to simply modulo the negative value with the curve's underlying field order.