### PR TITLE
PAIR: Add Shuffle

### DIFF
--- a/pkg/pair/pair.go
+++ b/pkg/pair/pair.go
@@ -122,9 +122,10 @@ func (pk *PrivateKey) Decrypt(ciphertext []byte) ([]byte, error) {
 }
 
 // Shuffle shuffles the data in place by using the Fisher-Yates algorithm.
-// Note that it should be called with less than 2^32-1 (4 billion)  elements.
+// Note that ideally, it should be called with less than 2^32-1 (4 billion) elements.
 func Shuffle(data [][]byte) {
-	// note that since go 1.20, math.Rand seeds the global random number generator.
+	// NOTE: since go 1.20, math.Rand seeds the global random number generator.
+	// V2 uses ChaCha8 generator as the global one.
 	mrandv2.Shuffle(len(data), func(i, j int) {
 		data[i], data[j] = data[j], data[i]
 	})

--- a/pkg/pair/pair.go
+++ b/pkg/pair/pair.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha512"
 	"errors"
 	"hash"
+	mrandv2 "math/rand/v2"
 
 	"github.com/gtank/ristretto255"
 )
@@ -118,4 +119,13 @@ func (pk *PrivateKey) Decrypt(ciphertext []byte) ([]byte, error) {
 	cipher.ScalarMult(inverse, cipher)
 
 	return cipher.MarshalText()
+}
+
+// Shuffle shuffles the data in place by using the Fisher-Yates algorithm.
+// Note that it should be called with less than 2^32-1 (4 billion)  elements.
+func Shuffle(data [][]byte) {
+	// note that since go 1.20, math.Rand seeds the global random number generator.
+	mrandv2.Shuffle(len(data), func(i, j int) {
+		data[i], data[j] = data[j], data[i]
+	})
 }

--- a/pkg/pair/pair_test.go
+++ b/pkg/pair/pair_test.go
@@ -1,8 +1,10 @@
 package pair
 
 import (
+	"bytes"
 	"crypto/rand"
 	"crypto/sha512"
+	"slices"
 	"strings"
 	"testing"
 
@@ -57,5 +59,47 @@ func TestPAIR(t *testing.T) {
 
 	if strings.Compare(string(ciphertext), string(decrypted)) != 0 {
 		t.Fatalf("want: %s, got: %s", string(ciphertext), string(decrypted))
+	}
+}
+
+func genData(n int) [][]byte {
+	data := make([][]byte, n)
+	for i := 0; i < n; i++ {
+		// marshaled ristretto255.Scalar is 44 bytes
+		data[i] = make([]byte, 44)
+		rand.Read(data[i])
+	}
+	return data
+}
+
+func TestShuffle(t *testing.T) {
+	data := genData(1 << 10) // 1k
+	orig := make([][]byte, len(data))
+	copy(orig, data)
+
+	// shuffle the data in place
+	Shuffle(data)
+
+	once := make([][]byte, len(data))
+	copy(once, data)
+
+	if slices.EqualFunc(data, orig, bytes.Equal) {
+		t.Fatalf("data not shuffled")
+	}
+
+	// shuffle again
+	Shuffle(data)
+
+	if slices.EqualFunc(data, once, bytes.Equal) {
+		t.Fatalf("data not shuffled")
+	}
+}
+
+func BenchmarkShuffleOneMillionIDs(b *testing.B) {
+	data := genData(1 << 20) // 1m
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		Shuffle(data)
 	}
 }


### PR DESCRIPTION
Add Shuffle function, and test. After running some benchmark between `math/rand` Shuffle and `math/rand/v2` Shuffle, v2 is always slightly faster:

```bash
go test -bench=. -v
=== RUN   TestPAIR
--- PASS: TestPAIR (0.00s)
goos: darwin
goarch: arm64
pkg: github.com/optable/match/pkg/pair
BenchmarkShuffleV1
BenchmarkShuffleV1-12    	     100	  11770306 ns/op
BenchmarkShuffleV2
BenchmarkShuffleV2-12    	     105	  11376890 ns/op
PASS
ok  	github.com/optable/match/pkg/pair	7.117s
```