### PR TITLE
Ci:Add initial workflow file

### DIFF
--- a/.github/workflows/match-ci.yml
+++ b/.github/workflows/match-ci.yml
@@ -1,0 +1,21 @@
+name: match-ci
+
+on: [pull_request]
+
+env:
+  GOPATH: ${{ github.workspace }}
+
+jobs:
+  test:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Set up Go 1.22.2
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22.2'
+      - name: Install dependencies
+        run: go get ./...
+      - name: Run tests
+        run: go test -v ./...

--- a/.github/workflows/match-ci.yml
+++ b/.github/workflows/match-ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/match-ci.yml
+++ b/.github/workflows/match-ci.yml
@@ -11,10 +11,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Set up Go 1.22.2
+      - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22.2'
+          go-version-file: '${{ env.GOPATH }}/go.mod'
       - name: Install dependencies
         run: go get ./...
       - name: Run tests


### PR DESCRIPTION
The initial workflow file for match ci is in GitHub actions


TODO: Another PR should remove legacy code once the gha workflow is officially adopted and make it mandatory before the PR is accepted for merge.